### PR TITLE
Fix KeyError of identity in result_item_dict

### DIFF
--- a/compass_contributor/contributor_dev_org_repo.py
+++ b/compass_contributor/contributor_dev_org_repo.py
@@ -411,7 +411,7 @@ class ContributorDevOrgRepo:
             for old_data in old_data_list_dict.values():
                 if old_data["uuid"] in merge_id_set:
                     for identity in item["id_identity_list"]:
-                        if identity in result_identity_uuid_dict.keys():
+                        if identity in result_identity_uuid_dict.keys() and result_identity_uuid_dict[identity] in result_item_dict.keys():
                             old_data = result_item_dict.pop(result_identity_uuid_dict[identity])
                             break
                 else:


### PR DESCRIPTION
Signed-off-by: edmondfrank <EdmondFrank@hotmail.com>

errors log as follow:
```
Traceback (most recent call last):
  File "/home/git/miniconda3/lib/python3.9/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/git/miniconda3/lib/python3.9/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/git/miniconda3/lib/python3.9/site-packages/celery/app/autoretry.py", line 54, in run
    ret = task.retry(exc=exc, **retry_kwargs)
  File "/home/git/miniconda3/lib/python3.9/site-packages/celery/app/task.py", line 717, in retry
    raise_with_context(exc)
  File "/home/git/miniconda3/lib/python3.9/site-packages/celery/app/autoretry.py", line 34, in run
    return task._orig_run(*args, **kwargs)
  File "/home/git/compass-service-scheduler/tasks/etl_v1.py", line 537, in contributors_refresh
    contributor_refresh = ContributorDevOrgRepo(**metrics_cfg['params'])
  File "/home/git/miniconda3/lib/python3.9/site-packages/compass_contributor/contributor_dev_org_repo.py", line 133, in run
    self.processing_data(repo)
  File "/home/git/miniconda3/lib/python3.9/site-packages/compass_contributor/contributor_dev_org_repo.py", line 162, in processing_data
    new_items_dict = self.get_merge_platform_git_contributor_data(self.git_item_id_dict, self.platform_item_id_dict)
  File "/home/git/miniconda3/lib/python3.9/site-packages/compass_contributor/contributor_dev_org_repo.py", line 387, in get_merge_platform_git_contributor_data
    result_item_dict, merge_id_set = self.get_merge_old_new_contributor_data(git_data_dict, platform_data_dict)
  File "/home/git/miniconda3/lib/python3.9/site-packages/compass_contributor/contributor_dev_org_repo.py", line 415, in get_merge_old_new_contributor_data
    old_data = result_item_dict.pop(result_identity_uuid_dict[identity])
KeyError: '23d32b2d0b53b2ed8645b88632cea715f33074fe'
```