### PR TITLE
fix: resolve KeyError in run.py and update Python version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ## Metrics Model 
 Metrics Model makes metrics combine  metrics together, you could find us [here](https://github.com/chaoss/wg-metrics-models) 
 
+### Requirements
+- Python >= 3.8 (required by grimoire_elk dependency)
+
 ### Please create json file as following way:
     
     {

--- a/run.py
+++ b/run.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
                  'pr_index', 'issue_comments_index', 'pr_comments_index', 'git_index', 'contributors_index', 'contributors_enriched_index',
                  'from_date', 'end_date', 'repo_index', 'event_index', 'company', 'stargazer_index',
                  'fork_index', 'level', 'community', 'contributors_org_index', 'organizations_index', 'bots_index']:
-      kwargs[item] = None if params[item] and params[item] == 'None' else params[item]
+      kwargs[item] = None if item not in params or params[item] == 'None' else params[item]
    contributor = ContributorDevOrgRepo(**kwargs)
    contributor.run(elastic_url)
 
@@ -35,21 +35,21 @@ if __name__ == '__main__':
    for item in ['issue_index', 'pr_index', 'repo_index', 'json_file', 'git_index',  'from_date', 'end_date',
                 'out_index', 'community', 'level', 'release_index', 'issue_comments_index', 'pr_comments_index',
                 'contributors_index']:
-       kwargs[item] = None if params[item] and params[item] == 'None' else params[item]
+       kwargs[item] = None if item not in params or params[item] == 'None' else params[item]
    model_activity = ActivityMetricsModel(**kwargs)
    model_activity.metrics_model_metrics(elastic_url)
 
    kwargs = {}
    for item in ['issue_index', 'pr_index', 'json_file', 'git_index', 'from_date', 'end_date', 'out_index', 'community',
                 'level', 'contributors_index']:
-       kwargs[item] = None if params[item] and params[item] == 'None' else params[item]
+       kwargs[item] = None if item not in params or params[item] == 'None' else params[item]
    model_community = CommunitySupportMetricsModel(**kwargs)
    model_community.metrics_model_metrics(elastic_url)
 
    kwargs = {}
    for item in ['issue_index', 'pr_index', 'json_file', 'git_index', 'from_date', 'end_date', 'out_index',
                'community', 'level', 'company', 'pr_comments_index', 'contributors_index']:
-      kwargs[item] = None if params[item] and params[item] == 'None' else params[item]
+      kwargs[item] = None if item not in params or params[item] == 'None' else params[item]
    model_code = CodeQualityGuaranteeMetricsModel(**kwargs)
    model_code.metrics_model_metrics(elastic_url)
 
@@ -57,7 +57,7 @@ if __name__ == '__main__':
    for item in ['issue_index', 'pr_index', 'repo_index', 'json_file', 'git_index',  'from_date', 'end_date',
                 'out_index', 'community', 'level', 'company', 'issue_comments_index', 'pr_comments_index',
                 'contributors_index']:
-       kwargs[item] = None if params[item] and params[item] == 'None' else params[item]
+       kwargs[item] = None if item not in params or params[item] == 'None' else params[item]
    model_organizations = OrganizationsActivityMetricsModel(**kwargs)
    model_organizations.metrics_model_metrics(elastic_url)
 

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,10 @@ setup(name="compass_metrics_model",
           'Topic :: Software Development',
           'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.4',
-          'Programming Language :: Python :: 3.5'],
+          'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11'],
       keywords="Metric Model",
       packages=find_packages(),
       package_data={
@@ -28,7 +30,7 @@ setup(name="compass_metrics_model",
           'compass_metrics': ['resources/*'],
           'compass_contributor': ['conf_utils/*']
       },
-      python_requires='>=3.4',
+      python_requires='>=3.8',
       setup_requires=['wheel'],
       zip_safe=False
       )


### PR DESCRIPTION
## Summary
Fixes #117

### Changes

1. **`run.py`** — Fix `KeyError` when optional params are missing from `conf.yaml`
   - **Before**: `kwargs[item] = None if params[item] and params[item] == 'None' else params[item]` — crashes with `KeyError` when a key is not in `params`
   - **After**: `kwargs[item] = None if item not in params or params[item] == 'None' else params[item]` — safely handles missing keys
   - Fixed all 5 instances of this pattern in `run.py`

2. **`setup.py`** — Update Python version requirement
   - Changed `python_requires` from `>=3.4` to `>=3.8`
   - Updated classifiers from `3.4, 3.5` to `3.8, 3.9, 3.10, 3.11`
   - This matches the actual requirement of the `grimoire_elk` dependency (see [grimoirelab-elk pyproject.toml](https://github.com/chaoss/grimoirelab-elk/blob/master/pyproject.toml))

3. **`README.md`** — Add Python version requirement note
   - Added `### Requirements` section with `Python >= 3.8` note

## Test plan
- [x] Both `run.py` and `setup.py` compile successfully
- [x] No logic changes, only error handling and version metadata fixes