### PR TITLE
fix: handle short contributor analysis windows

### DIFF
--- a/compass_metrics/contributor_metrics.py
+++ b/compass_metrics/contributor_metrics.py
@@ -468,8 +468,7 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
             or the group that contributes 3/4 of the time in this timeframe (excluding star and fork contributions).
         """
         date_list = [x for x in list(pd.date_range(freq='W-MON', start=from_date, end=date))]
-        if len(date_list) >= 4:
-            weeks = len(date_list) * 3 / 4
+        weeks = len(date_list) * 3 / 4 if len(date_list) >= 4 else None
         contribution_count_dict = {k: v["contribution_without_observe"] for k, v in contributor_dict.items()}
         sorted_dict = {k: v for k, v in
                         sorted(contribution_count_dict.items(), key=lambda item: item[1], reverse=True)}
@@ -482,7 +481,7 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
             if current_sum >= target_sum:
                 break
         for k, v in contributor_dict.items():
-            if v["contribution_weeks"] >= weeks:
+            if weeks is not None and v["contribution_weeks"] >= weeks:
                 result_contributor[k] = {**v, "mileage_type": "regular"}
         core_name = core_contributor.keys()
         return {k: result_contributor[k] for k in result_contributor.keys() if k not in core_name}

--- a/tests/test_contributor_metrics.py
+++ b/tests/test_contributor_metrics.py
@@ -1,0 +1,36 @@
+import unittest
+from datetime import date
+from unittest.mock import patch
+
+from compass_metrics.contributor_metrics import contributor_detail_list
+
+
+class ContributorDetailListTest(unittest.TestCase):
+    def test_short_analysis_window_does_not_use_an_uninitialized_week_threshold(self):
+        contributors = [{
+            "contributor": "alice",
+            "contribution": 1,
+            "contribution_without_observe": 1,
+            "ecological_type": "individual participant",
+            "organization": None,
+            "contribution_type_list": [],
+            "is_bot": False,
+            "repo_name": "example/repo",
+        }]
+
+        with patch("compass_metrics.contributor_metrics.get_contributor_list", return_value=contributors):
+            result = contributor_detail_list(
+                client=None,
+                contributors_enriched_index="contributors",
+                date=date(2026, 7, 12),
+                repo_list=["example/repo"],
+                from_date=date(2026, 7, 11),
+            )
+
+        self.assertEqual(result["core_count"], 1)
+        self.assertEqual(result["regular_count"], 0)
+        self.assertEqual(result["casual_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #195.

- Prevents uninitialized `weeks` access for analysis windows shorter than four weeks.
- Preserves the prior behavior for short windows by skipping the 3/4-weeks regular-contributor criterion when it cannot be evaluated.
- Adds a one-day-window regression test.

## Root cause

`get_regular_contributor()` initialized `weeks` only for ranges with at least four week boundaries, then used it unconditionally.

## Validation

- `python -m compileall -q compass_metrics tests`
- Regression `unittest` for a one-day analysis window