### PR TITLE
fix: 开发者分层统计误判——头部贡献者被计入 regular/visitor，core 恒为 0

### DIFF
--- a/compass_metrics_v2/developer_metrics_v2.py
+++ b/compass_metrics_v2/developer_metrics_v2.py
@@ -750,6 +750,8 @@ def _tier_counts_from_contribution_map(contribution_map, core_ratio=0.5, regular
     """
     根据贡献量占比划分 core / regular / visitor，返回 (core_count, regular_count, visitor_count)。
     core: 累计贡献占比前 50% 的开发者；regular: 累计 50%–80%（即常客 20%–50% 贡献）；visitor: 剩余 <20%。
+    按累加前的累计占比归类：跨越 50% 边界的头部开发者归入 core，与
+    _get_core_contributor_set_from_maps（晋升/留存/流失）的口径保持一致。
     """
     if not contribution_map:
         return 0, 0, 0
@@ -760,14 +762,14 @@ def _tier_counts_from_contribution_map(contribution_map, core_ratio=0.5, regular
     cum = 0.0
     core_count = regular_count = visitor_count = 0
     for _, v in sorted_contributors:
-        cum += v
         ratio = cum / total
-        if ratio <= core_ratio:
+        if ratio < core_ratio:
             core_count += 1
-        elif ratio <= regular_end_ratio:
+        elif ratio < regular_end_ratio:
             regular_count += 1
         else:
             visitor_count += 1
+        cum += v
     return core_count, regular_count, visitor_count
 
 

--- a/tests/test_developer_metrics_v2_tiers.py
+++ b/tests/test_developer_metrics_v2_tiers.py
@@ -1,0 +1,50 @@
+import unittest
+
+from compass_metrics_v2.developer_metrics_v2 import (
+    _get_core_contributor_set_from_maps,
+    _tier_counts_from_contribution_map,
+)
+
+
+class TierCountsFromContributionMapTest(unittest.TestCase):
+    """core/regular/visitor 分层应基于"累计贡献占比前 50%/80%"划分，
+    且与晋升/留存使用的 _get_core_contributor_set_from_maps 口径一致。"""
+
+    def test_single_contributor_is_core(self):
+        # 仓库唯一的贡献者就是核心贡献者，不应被划分为 visitor
+        self.assertEqual(_tier_counts_from_contribution_map({"alice": 100}), (1, 0, 0))
+
+    def test_dominant_contributor_is_core(self):
+        # 头部贡献者覆盖 60% 贡献量，属于 core；第二位处于 50%-80% 区间，属于 regular
+        self.assertEqual(_tier_counts_from_contribution_map({"a": 60, "b": 40}), (1, 1, 0))
+
+    def test_majority_contributor_is_core(self):
+        # 覆盖 51% 贡献量的贡献者是 core，而不是 regular
+        self.assertEqual(_tier_counts_from_contribution_map({"a": 51, "b": 49}), (1, 1, 0))
+
+    def test_uniform_contributors(self):
+        # 10 个均等贡献者：前 5 位覆盖 50% 为 core，接下来 3 位覆盖到 80% 为 regular
+        contributions = {f"c{i}": 10 for i in range(10)}
+        self.assertEqual(_tier_counts_from_contribution_map(contributions), (5, 3, 2))
+
+    def test_empty_map(self):
+        self.assertEqual(_tier_counts_from_contribution_map({}), (0, 0, 0))
+
+    def test_zero_total_contributions(self):
+        # 全部贡献量为 0 时无法划分层级，全部算作 visitor
+        self.assertEqual(_tier_counts_from_contribution_map({"a": 0, "b": 0}), (0, 0, 2))
+
+    def test_core_set_consistency_with_tier_counts(self):
+        # 分层函数与核心集合函数对 core 的界定必须一致
+        for contributions in ({"a": 100}, {"a": 60, "b": 40}, {"a": 51, "b": 49}, {"a": 30, "b": 30, "c": 40}):
+            core_count, _, _ = _tier_counts_from_contribution_map(contributions)
+            core_set = _get_core_contributor_set_from_maps(contributions, {}, dimension="code", core_ratio=0.5)
+            self.assertEqual(
+                core_count,
+                len(core_set),
+                f"core count mismatch for {contributions}: tier={core_count}, set={sorted(core_set)}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 缺陷

`compass_metrics_v2/developer_metrics_v2.py` 中 `_tier_counts_from_contribution_map`（被 12 个 `*_core/regular/visitor_contributors_by_period` 指标使用）在累加**之后**才用累计占比判断层级，导致跨越 50%/80% 边界的头部开发者被挤到下一个层级。

## 稳定复现

```python
from compass_metrics_v2.developer_metrics_v2 import _tier_counts_from_contribution_map

_tier_counts_from_contribution_map({"alice": 100})    # => (0, 0, 1)
_tier_counts_from_contribution_map({"a": 60, "b": 40})  # => (0, 1, 1)
_tier_counts_from_contribution_map({"a": 51, "b": 49})  # => (0, 1, 1)
```

- 只有一个贡献者的仓库：core=0、visitor=1 —— 唯一的贡献者被标成"访客"；
- 头部贡献者覆盖 60% 贡献量的仓库：core=0 —— 头部贡献者被标成"常客"。

## 口径不一致

晋升/留存/流失指标（`org_code_core_promotion_count_by_period`、`*_core_retention/churn/loss_by_period` 等）使用的 `_get_core_contributor_set_from_maps` 是"累加后**包含**跨越者"（`cum >= total * core_ratio` 才 break，但跨越者已加入集合）。同一个贡献者在留存指标里算 core、在数量指标里不算，同一个模块内两种口径互相矛盾。

## 修复

改为按累加**之前**的累计占比归类（跨越 50% 边界的头部开发者归入 core），与函数 docstring（"core: 累计贡献占比前 50% 的开发者"）以及 `_get_core_contributor_set_from_maps` 的口径保持一致。均匀分布等常规场景结果不变（10 个均等贡献者仍为 core=5, regular=3, visitor=2）。

## 测试

新增 `tests/test_developer_metrics_v2_tiers.py`（unittest，7 个用例）：

- 单一贡献者 → (1, 0, 0)；60/40、51/49 → (1, 1, 0)；
- 均匀分布 → (5, 3, 2)；空/零贡献边界；
- 分层函数与 `_get_core_contributor_set_from_maps` 对每组输入的 core 数量一致。