### PR TITLE
fix: ecology_test_coverage 无法解析 SonarQube 小数字符串，得分恒为 0

### DIFF
--- a/compass_metrics_v2/supply_chain_security_metrics_v2.py
+++ b/compass_metrics_v2/supply_chain_security_metrics_v2.py
@@ -521,7 +521,9 @@ def _calc_ecology_test_coverage(sonar_scanner_result: Dict[str, Any]) -> Dict[st
         metric = m.get("metric")
         if metric == "duplicated_lines_density":
             try:
-                duplication_ratio = int(m.get("value") or 0)
+                # SonarQube 组件测量接口返回的 value 是字符串（如 "65.0"），
+                # 需先转 float 再取整，否则小数字符串会解析失败
+                duplication_ratio = int(float(m.get("value") or 0))
             except (TypeError, ValueError):
                 duplication_ratio = None
             for lo, hi, sc in ranges_dup:
@@ -530,7 +532,7 @@ def _calc_ecology_test_coverage(sonar_scanner_result: Dict[str, Any]) -> Dict[st
                     break
         elif metric == "coverage":
             try:
-                coverage_ratio = int(m.get("value") or 0)
+                coverage_ratio = int(float(m.get("value") or 0))
             except (TypeError, ValueError):
                 coverage_ratio = None
             for lo, hi, sc in ranges_cov:

--- a/tests/test_supply_chain_security_coverage.py
+++ b/tests/test_supply_chain_security_coverage.py
@@ -1,0 +1,55 @@
+import unittest
+
+from compass_metrics_v2.supply_chain_security_metrics_v2 import _calc_ecology_test_coverage
+
+
+class EcologyTestCoverageTest(unittest.TestCase):
+    """SonarQube 组件测量接口返回的 value 是字符串（如 "65.0"），
+    解析不应因小数字符串而静默失败。"""
+
+    def test_sonar_string_values_are_parsed(self):
+        result = _calc_ecology_test_coverage({
+            "component": {
+                "measures": [
+                    {"metric": "duplicated_lines_density", "value": "3.4"},
+                    {"metric": "coverage", "value": "65.0"},
+                ]
+            }
+        })
+        # 重复率 3% -> 8 分；覆盖率 65% -> 6 分；总分 (8+6)/2 = 7
+        self.assertEqual(result["ecology_test_coverage"], 7.0)
+        detail = __import__("json").loads(result["ecology_test_coverage_detail"])
+        self.assertEqual(detail["duplication_ratio"], 3)
+        self.assertEqual(detail["coverage_ratio"], 65)
+
+    def test_integer_string_values_are_parsed(self):
+        result = _calc_ecology_test_coverage({
+            "component": {
+                "measures": [
+                    {"metric": "duplicated_lines_density", "value": "0"},
+                    {"metric": "coverage", "value": "80"},
+                ]
+            }
+        })
+        # 重复率 0% -> 10 分；覆盖率 80% -> 10 分
+        self.assertEqual(result["ecology_test_coverage"], 10.0)
+
+    def test_numeric_values_still_work(self):
+        result = _calc_ecology_test_coverage({
+            "component": {
+                "measures": [
+                    {"metric": "duplicated_lines_density", "value": 10},
+                    {"metric": "coverage", "value": 50},
+                ]
+            }
+        })
+        # 重复率 10% -> 4 分；覆盖率 50% -> 6 分
+        self.assertEqual(result["ecology_test_coverage"], 5.0)
+
+    def test_missing_measures_fall_back_to_zero(self):
+        result = _calc_ecology_test_coverage({"component": {"measures": []}})
+        self.assertEqual(result["ecology_test_coverage"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 缺陷

`compass_metrics_v2/supply_chain_security_metrics_v2.py` 的 `_calc_ecology_test_coverage` 用 `int(value)` 解析 SonarQube 测量值。SonarQube 组件测量接口（`component.measures`）返回的 `value` 是**字符串**，且百分比类指标普遍带小数（如 coverage `"65.0"`、duplicated_lines_density `"3.4"`）。`int("65.0")` 抛出 `ValueError` 后被 `except` 吞掉并把比率置为 `None`，两个得分项静默归零。

## 稳定复现

```python
from compass_metrics_v2.supply_chain_security_metrics_v2 import _calc_ecology_test_coverage

_calc_ecology_test_coverage({"component": {"measures": [
    {"metric": "duplicated_lines_density", "value": "3.4"},
    {"metric": "coverage", "value": "65.0"},
]}})
# 修复前: ecology_test_coverage = 0.0, duplication_ratio=None, coverage_ratio=None
# 修复后: ecology_test_coverage = 7.0（重复率 3% -> 8 分, 覆盖率 65% -> 6 分, (8+6)/2）
```

即对真实 Sonar 数据，`ecology_test_coverage`（被 Development Document Quality / Code Review Quality 模型使用）基本恒为 0 或缺失。

## 修复

`int(float(value))` 兼容小数字符串、整数字符串与数值型输入；解析失败仍回退 `None` 不影响其他指标。

## 测试

新增 `tests/test_supply_chain_security_coverage.py`（4 个用例）：小数字符串、整数字符串、数值型、空 measures 边界。