### PR TITLE
fix: v2 metrics_model_enrich 评分被重复计算两次，且异常兜底失效

### DIFF
--- a/compass_model/base_metrics_model_v2.py
+++ b/compass_model/base_metrics_model_v2.py
@@ -540,7 +540,6 @@ class BaseMetricsModel:
                 **self.custom_fields
             }
             cache_last_metrics_data(metrics_data, last_metrics_data)
-            metrics_data["score"] = self.get_metrics_score(self.metrics_decay(metrics_data, last_metrics_data))
             try:
                 metrics_data["score"] = self.get_metrics_score(self.metrics_decay(metrics_data, last_metrics_data))
             except Exception as e:

--- a/tests/test_base_metrics_model_v2_score.py
+++ b/tests/test_base_metrics_model_v2_score.py
@@ -1,0 +1,65 @@
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from compass_model.base_metrics_model_v2 import BaseMetricsModel
+
+
+def make_model():
+    return BaseMetricsModel(
+        repo_index="repo-idx", git_index="git-idx", issue_index="issue-idx", pr_index="pr-idx",
+        issue_comments_index="issue-cmt-idx", pr_comments_index="pr-cmt-idx",
+        contributors_index="contributor-idx", release_index="release-idx", out_index="out-idx",
+        from_date="2026-01-01", end_date="2026-08-01", level="repo", community="demo", source="github",
+        json_file="repos.json", model_name="Demo Model",
+        metrics_weights_thresholds={"comment_frequency": {"weight": 1, "threshold": 15}},
+        custom_fields={"period": "month"},
+    )
+
+
+def enrich_patches():
+    return [
+        patch("compass_model.base_metrics_model_v2.get_client", return_value=MagicMock()),
+        patch("compass_model.base_metrics_model_v2.add_release_message"),
+        patch("compass_model.base_metrics_model_v2.created_since", return_value={"created_since": 100}),
+        patch("compass_model.base_metrics_model_v2.get_date_list_by_period",
+              return_value=[datetime(2026, 8, 1)]),
+    ]
+
+
+class MetricsModelEnrichScoreTest(unittest.TestCase):
+    """metrics_model_enrich 中评分只应计算一次，且评分异常时应回退为 0 而不是中断整个任务。"""
+
+    def test_score_failure_falls_back_to_zero_instead_of_crashing(self):
+        model = make_model()
+        patches = enrich_patches()
+        with patches[0], patches[1], patches[2], patches[3], \
+                patch("compass_model.base_metrics_model_v2.helpers") as helpers_mock:
+            model.get_metrics = MagicMock(return_value=({"comment_frequency": 3}, {}))
+            model.metrics_decay = MagicMock(side_effect=lambda metrics_data, last_data: metrics_data)
+            model.get_metrics_score = MagicMock(side_effect=RuntimeError("boom"))
+
+            model.metrics_model_enrich(["org/repo"], "org/repo", "repo")
+
+            bulk_actions = []
+            for call in helpers_mock.return_value.bulk.call_args_list:
+                bulk_actions.extend(call.kwargs["actions"])
+            self.assertEqual(len(bulk_actions), 1)
+            self.assertEqual(bulk_actions[0]["_source"]["score"], 0)
+
+    def test_score_is_computed_exactly_once_per_period(self):
+        model = make_model()
+        patches = enrich_patches()
+        with patches[0], patches[1], patches[2], patches[3], \
+                patch("compass_model.base_metrics_model_v2.helpers"):
+            model.get_metrics = MagicMock(return_value=({"comment_frequency": 3}, {}))
+            model.metrics_decay = MagicMock(side_effect=lambda metrics_data, last_data: metrics_data)
+            model.get_metrics_score = MagicMock(return_value=0.42)
+
+            model.metrics_model_enrich(["org/repo"], "org/repo", "repo")
+
+            self.assertEqual(model.get_metrics_score.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 缺陷

`compass_model/base_metrics_model_v2.py` 的 `metrics_model_enrich` 中存在两行完全相同的评分调用：

```python
cache_last_metrics_data(metrics_data, last_metrics_data)
metrics_data["score"] = self.get_metrics_score(self.metrics_decay(metrics_data, last_metrics_data))  # 无保护
try:
    metrics_data["score"] = self.get_metrics_score(self.metrics_decay(metrics_data, last_metrics_data))  # 有保护
except Exception as e:
    print(f"[Warning] Failed to compute score for ...: {e}")
    metrics_data["score"] = 0
```

由 commit f6b35be 引入（在原有 try/except 之上新加了一行无保护调用，而不是替换它）。后果：

1. **每个周期评分计算两遍**（`get_metrics_score` + `metrics_decay` 全量重跑），纯浪费；
2. **兜底逻辑失效**：`get_metrics_score` 一旦抛异常（如 `get_param_score` 在阈值为 0 时的除零、权重配置问题等），异常在**无保护那行**就冲出循环，整个模型的 enrich 任务中断——下方专门写的 "[Warning] ... score = 0" 兜底对它想防御的故障完全不起作用。

v1 的 `metrics_model_enrich`（`compass_model/base_metrics_model.py`）只有带保护的版本，可见无保护那行是遗留/误加。

## 修复

删除无保护的重复调用，保留 try/except 版本（与 v1 行为一致）。

## 测试

新增 `tests/test_base_metrics_model_v2_score.py`（2 个用例，mock 全部外部依赖、无需 ES）：

- `get_metrics_score` 抛异常时，enrich 正常完成且落库 score=0（修复前直接抛 RuntimeError 中断）；
- 每个周期 `get_metrics_score` 恰好调用 1 次（修复前为 2 次）。