### PR TITLE
fix: pr_comment_count_by_period 查询空周期区间且绑定错误索引，指标恒为 0

### DIFF
--- a/compass_metrics_v2/pr_metrics_v2.py
+++ b/compass_metrics_v2/pr_metrics_v2.py
@@ -36,7 +36,27 @@ def get_period_range(end_date: datetime, period: str):
     else:  # quarter
         month = ((end_date.month - 1) // 3) * 3 + 1
         start_date = end_date.replace(month=month, day=1, hour=0, minute=0, second=0, microsecond=0)
-    return start_date, end_date
+
+    # 与 issue/repo/developer/contributor/git 各模块一致：窗口结束时间规范化到周期最后一天。
+    # enrich 循环传入的是周期第一天，若直接用其作为 to_date，
+    # 查询区间会变成 gte X lt X 的空区间，导致当前窗口指标恒为 0。
+    if period == "month":
+        if end_date.month == 12:
+            next_month = end_date.replace(year=end_date.year + 1, month=1, day=1)
+        else:
+            next_month = end_date.replace(month=end_date.month + 1, day=1)
+        actual_end_date = next_month - timedelta(seconds=1)
+    elif period == "year":
+        actual_end_date = end_date.replace(month=12, day=31, hour=23, minute=59, second=59)
+    else:  # quarter
+        quarter_end_month = ((end_date.month - 1) // 3) * 3 + 3
+        if quarter_end_month == 12:
+            next_start = end_date.replace(year=end_date.year + 1, month=1, day=1)
+        else:
+            next_start = end_date.replace(month=quarter_end_month + 1, day=1)
+        actual_end_date = next_start - timedelta(seconds=1)
+
+    return start_date, actual_end_date
 
 
 def get_previous_period_range(end_date: datetime, period: str):

--- a/compass_model/base_metrics_model_v2.py
+++ b/compass_model/base_metrics_model_v2.py
@@ -892,7 +892,7 @@ class BaseMetricsModel:
             "lines_changed_by_period": lambda: lines_changed_by_period(self.client, self.contributors_enriched_index, date,repo_list,period),
             "issue_comment_activity_by_period": lambda: issue_comment_activity_by_period(self.client, self.issue_index, date,repo_list,period),
             "issue_new_count_by_period": lambda: issue_new_count_by_period(self.client, self.issue_index, date,repo_list,period),
-            "pr_comment_count_by_period": lambda: pr_comment_count_by_period(self.client, self.issue_index, date,repo_list,period),
+            "pr_comment_count_by_period": lambda: pr_comment_count_by_period(self.client, self.pr_index, date,repo_list,period),
 
             "repo_forks_by_period": lambda: repo_forks_by_period(self.client, self.repo_index, date, repo_list,period),
             "repo_stars_by_period": lambda: repo_stars_by_period(self.client, self.repo_index, date, repo_list,period),

--- a/tests/test_period_enrich_flow.py
+++ b/tests/test_period_enrich_flow.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from compass_model_v2.community_health.community_vitality.contribution_activity_metrics_model import (
+    ContributionActivityMetricsModel,
+)
+
+
+class RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    def search(self, index=None, body=None, **kwargs):
+        self.calls.append({"index": index, "body": body})
+        return {"hits": {"total": {"value": 3}},
+                "aggregations": {"count_of_uuid": {"value": 5, "values": {"50.0": 2.0}}}}
+
+
+class ContributionActivityEnrichFlowTest(unittest.TestCase):
+    """用真实模型跑完整 enrich 流程，验证周期查询的整类缺陷：
+    - 周期窗口不得出现 gte == lt 的空区间（pr_metrics_v2.get_period_range 修复点）；
+    - pr_comment_count_by_period 必须查询 PR 索引（switch 绑定修复点）。
+    该测试覆盖全部按周期指标在真实调用路径上的行为。"""
+
+    def run_enrich(self, client):
+        model = ContributionActivityMetricsModel(
+            repo_index="repo-idx", git_index="git-idx", issue_index="issue-idx", pr_index="pr-idx",
+            issue_comments_index="issue-cmt-idx", pr_comments_index="pr-cmt-idx",
+            contributors_index="contrib-idx", release_index="release-idx", out_index="out-idx",
+            from_date="2026-06-01", end_date="2026-08-15", level="repo", community="demo",
+            source="github", json_file="repos.json", contributors_enriched_index="ce-idx",
+            custom_fields={"period": "month"})
+        model.client = client
+        with patch("compass_model.base_metrics_model_v2.get_client", return_value=client), \
+                patch("compass_model.base_metrics_model_v2.get_repo_list", return_value=["org/repo"]), \
+                patch("compass_model.base_metrics_model_v2.created_since", return_value={"created_since": 100}), \
+                patch("compass_model.base_metrics_model_v2.add_release_message"), \
+                patch("compass_model.base_metrics_model_v2.helpers"):
+            model.metrics_model_metrics("http://es:9200")
+        return model
+
+    def test_no_period_query_uses_an_empty_window(self):
+        client = RecordingClient()
+        self.run_enrich(client)
+        for call in client.calls:
+            for f in call["body"].get("query", {}).get("bool", {}).get("filter", []):
+                rng = f.get("range", {}).get("grimoire_creation_date")
+                if rng:
+                    self.assertNotEqual(rng["gte"], rng["lt"],
+                                        f"{call['index']} 查询出现空区间: {rng}")
+
+    def test_june_window_covers_the_whole_month(self):
+        client = RecordingClient()
+        self.run_enrich(client)
+        june_ends = set()
+        for call in client.calls:
+            for f in call["body"].get("query", {}).get("bool", {}).get("filter", []):
+                rng = f.get("range", {}).get("grimoire_creation_date")
+                if rng and rng.get("gte", "").startswith("2026-06"):
+                    june_ends.add(rng["lt"])
+        self.assertTrue(june_ends)
+        for lt in june_ends:
+            self.assertGreaterEqual(lt, "2026-06-29")
+
+    def test_pr_comment_count_queries_the_pr_index(self):
+        client = RecordingClient()
+        self.run_enrich(client)
+        pr_calls = [c for c in client.calls if c["index"] == "pr-idx"]
+        self.assertTrue(pr_calls, "没有任何查询落在 PR 索引上")
+        for call in pr_calls:
+            must = call["body"]["query"]["bool"]["must"]
+            self.assertTrue(
+                any(q.get("match_phrase", {}).get("pull_request") == "true" for q in must))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_comment_count_period.py
+++ b/tests/test_pr_comment_count_period.py
@@ -1,0 +1,94 @@
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+from compass_metrics_v2.pr_metrics_v2 import get_period_range, pr_comment_count_by_period
+from compass_model.base_metrics_model_v2 import BaseMetricsModel
+
+
+SEARCH_RESPONSE = {
+    "hits": {"total": {"value": 5}},
+    "aggregations": {"count_of_uuid": {"value": 7}},
+}
+
+
+class RecordingClient:
+    def __init__(self):
+        self.search_calls = []
+
+    def search(self, index=None, body=None):
+        self.search_calls.append({"index": index, "body": body})
+        return SEARCH_RESPONSE
+
+
+class GetPeriodRangeTest(unittest.TestCase):
+    """pr_metrics_v2 的 get_period_range 应与 issue/repo/developer/contributor/git
+    各模块一致，将窗口结束时间规范化到周期最后一天。
+    否则 enrich 循环传入周期第一天时，查询区间为 gte X lt X 的空区间，
+    当前窗口的 PR 周期指标恒为 0。"""
+
+    def test_month_window_covers_whole_month(self):
+        start, end = get_period_range(datetime(2026, 8, 1), "month")
+        self.assertEqual(start, datetime(2026, 8, 1))
+        self.assertEqual(end, datetime(2026, 8, 31, 23, 59, 59))
+
+    def test_quarter_window_covers_whole_quarter(self):
+        start, end = get_period_range(datetime(2026, 8, 1), "quarter")
+        self.assertEqual(start, datetime(2026, 7, 1))
+        self.assertEqual(end, datetime(2026, 9, 30, 23, 59, 59))
+
+    def test_year_window_covers_whole_year(self):
+        start, end = get_period_range(datetime(2026, 2, 1), "year")
+        self.assertEqual(start, datetime(2026, 1, 1))
+        self.assertEqual(end, datetime(2026, 12, 31, 23, 59, 59))
+
+    def test_invalid_period_rejected(self):
+        with self.assertRaises(ValueError):
+            get_period_range(datetime(2026, 8, 1), "week")
+
+
+class PrCommentCountByPeriodTest(unittest.TestCase):
+    def test_query_covers_current_period_not_a_single_moment(self):
+        client = RecordingClient()
+        result = pr_comment_count_by_period(client, "pr-idx", datetime(2026, 8, 1), ["org/repo"], "month")
+
+        date_range = client.search_calls[0]["body"]["query"]["bool"]["filter"][0]["range"]["grimoire_creation_date"]
+        self.assertEqual(date_range["gte"], "2026-08-01")
+        self.assertEqual(date_range["lt"], "2026-08-31")
+        self.assertEqual(result["pr_comment_count"], 7)
+
+    def test_queries_pr_index_with_pr_filter(self):
+        client = RecordingClient()
+        pr_comment_count_by_period(client, "pr-idx", datetime(2026, 8, 1), ["org/repo"], "month")
+
+        self.assertEqual(client.search_calls[0]["index"], "pr-idx")
+        self.assertEqual(
+            client.search_calls[0]["body"]["query"]["bool"]["must"][-1],
+            {"match_phrase": {"pull_request": "true"}},
+        )
+
+
+class PrCommentCountSwitchBindingTest(unittest.TestCase):
+    """metrics_switch 中 pr_comment_count_by_period 应绑定 PR 索引，
+    而不是 issue 索引（其余 pr_* 指标均绑定 pr_index）。"""
+
+    def test_pr_comment_count_queries_pr_index(self):
+        client = RecordingClient()
+        model = BaseMetricsModel(
+            repo_index="repo-idx", git_index="git-idx", issue_index="issue-idx", pr_index="pr-idx",
+            issue_comments_index="issue-cmt-idx", pr_comments_index="pr-cmt-idx",
+            contributors_index="contributor-idx", release_index="release-idx", out_index="out-idx",
+            from_date="2026-01-01", end_date="2026-08-01", level="repo", community="demo", source="github",
+            json_file="repos.json", model_name="Demo Model",
+            metrics_weights_thresholds={"pr_comment_count_by_period": {"weight": 1, "threshold": 1}},
+            custom_fields={"period": "month"},
+        )
+        model.client = client
+
+        model.get_metrics(datetime(2026, 8, 1), ["org/repo"], "month")
+
+        self.assertEqual(client.search_calls[0]["index"], "pr-idx")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 缺陷

`pr_comment_count_by_period`（Contribution Activity 模型在用）存在两个相互独立的缺陷，叠加导致该指标**任何周期都返回 0**：

### 1. 周期区间为空

`compass_metrics_v2/pr_metrics_v2.py` 的 `get_period_range` 直接把传入的 `end_date` 原样作为窗口结束返回，而 issue/repo/developer/contributor/git 五个 v2 模块中的同功能函数都会把窗口结束规范化为**周期最后一天**（如 `next_month - timedelta(seconds=1)`）。

v2 的 enrich 循环（`metrics_model_enrich` → `get_date_list_by_period`）传入的是周期**第一天**（如 2026-08-01 00:00），`get_uuid_count_query` 用 `%Y-%m-%d` 格式化后生成的区间是：

```
"gte": "2026-08-01", "lt": "2026-08-01"   # 空区间！
```

所有用 `get_period_range` 取**当前窗口**的 PR 指标全部受影响（注册在 metrics_switch 中的为 `pr_comment_count_by_period`）。

### 2. 绑定错误索引

`base_metrics_model_v2.py` 的 metrics_switch 中：

```python
"pr_comment_count_by_period": lambda: pr_comment_count_by_period(self.client, self.issue_index, date, repo_list, period)
```

其余所有 `pr_*` 指标均绑定 `self.pr_index`；该函数本身带 `pull_request: "true"` 过滤，却拿去查 issue 索引。

## 稳定复现

```python
from compass_metrics_v2.pr_metrics_v2 import get_period_range
get_period_range(datetime(2026, 8, 1), "month")
# 修复前: (2026-08-01, 2026-08-01)          -> 区间 [8/1, 8/1) 为空
# 修复后: (2026-08-01, 2026-08-31 23:59:59) -> 与其他 5 个模块一致
```

## 修复

- `get_period_range` 补齐周期末尾规范化，与兄弟模块逐行一致；
- switch 绑定改为 `self.pr_index`。

## 测试

- 新增 `tests/test_pr_comment_count_period.py`（7 个用例）：月/季/年窗口端点、非法 period、捕获查询体断言区间覆盖整个周期且落在 `pr_index` 上、模型级断言 switch 绑定的是 `pr-idx`；
- 新增 `tests/test_period_enrich_flow.py`（3 个用例）：用真实 ContributionActivity 模型跑完整 `metrics_model_metrics` enrich 流程（stub ES），对全部按周期查询断言——无任何 `gte == lt` 空区间、六月窗口覆盖到 6-30、PR 评论查询落在 PR 索引——把这类"空窗口"缺陷在真实调用路径上整链钉死。
