### PR TITLE
fix: metrics model 分发级联失效——version 类模型同时跑两条 enrich 管线

### DIFF
--- a/compass_model/base_metrics_model.py
+++ b/compass_model/base_metrics_model.py
@@ -354,9 +354,9 @@ class BaseMetricsModel:
                      if metric_field:
                          if '_year' in metric_field:
                              self.metrics_model_enrich_year([repo], repo, self.level)
-                         if 'license' in metric_field or 'security' in metric_field or 'activity_quarterly_' in metric_field:
+                         elif 'license' in metric_field or 'security' in metric_field or 'activity_quarterly_' in metric_field:
                              self.metrics_model_enrich_version([repo], repo, self.level)
-                         if 'doc_' in metric_field or metric_field == 'org_contribution' or 'vul_' in metric_field:
+                         elif 'doc_' in metric_field or metric_field == 'org_contribution' or 'vul_' in metric_field:
                              self.metrics_model_enrich_version([repo], repo, self.level)
                          else:
                              self.metrics_model_enrich([repo], repo, self.level)
@@ -369,7 +369,7 @@ class BaseMetricsModel:
                     if len(combined_repo_list) > 0:
                         self.metrics_model_enrich_year(software_artifact_repo_list, self.community, self.level,
                                                   SOFTWARE_ARTIFACT)
-                if 'license' in metric_field or 'security' in metric_field or 'activity_quarterly_' in metric_field:
+                elif 'license' in metric_field or 'security' in metric_field or 'activity_quarterly_' in metric_field:
                     combined_repo_list = software_artifact_repo_list + governance_repo_list
                     if len(combined_repo_list) > 0:
                         self.metrics_model_enrich_version(software_artifact_repo_list, self.community, self.level,

--- a/compass_model/base_metrics_model_v2.py
+++ b/compass_model/base_metrics_model_v2.py
@@ -468,9 +468,9 @@ class BaseMetricsModel:
                      if metric_field:
                          if '_year' in metric_field:
                              self.metrics_model_enrich_year([repo], repo, self.level)
-                         if 'license' in metric_field or 'security' in metric_field or 'activity_quarterly_' in metric_field:
+                         elif 'license' in metric_field or 'security' in metric_field or 'activity_quarterly_' in metric_field:
                              self.metrics_model_enrich_version([repo], repo, self.level)
-                         if 'doc_' in metric_field or metric_field == 'org_contribution' or 'vul_' in metric_field:
+                         elif 'doc_' in metric_field or metric_field == 'org_contribution' or 'vul_' in metric_field:
                              self.metrics_model_enrich_version([repo], repo, self.level)
                          else:
                              self.metrics_model_enrich([repo], repo, self.level)
@@ -483,7 +483,7 @@ class BaseMetricsModel:
                     if len(combined_repo_list) > 0:
                         self.metrics_model_enrich_year(software_artifact_repo_list, self.community, self.level,
                                                   SOFTWARE_ARTIFACT)
-                if 'license' in metric_field or 'security' in metric_field or 'activity_quarterly_' in metric_field:
+                elif 'license' in metric_field or 'security' in metric_field or 'activity_quarterly_' in metric_field:
                     combined_repo_list = software_artifact_repo_list + governance_repo_list
                     if len(combined_repo_list) > 0:
                         self.metrics_model_enrich_version(software_artifact_repo_list, self.community, self.level,

--- a/tests/test_metrics_model_dispatch.py
+++ b/tests/test_metrics_model_dispatch.py
@@ -1,0 +1,148 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from compass_model.base_metrics_model import BaseMetricsModel as BaseMetricsModelV1
+from compass_model.base_metrics_model_v2 import BaseMetricsModel as BaseMetricsModelV2
+
+
+def make_model(model_cls, first_metric):
+    kwargs = dict(
+        repo_index="repo-idx", git_index="git-idx", issue_index="issue-idx", pr_index="pr-idx",
+        issue_comments_index="issue-cmt-idx", pr_comments_index="pr-cmt-idx",
+        contributors_index="contributor-idx", release_index="release-idx", out_index="out-idx",
+        from_date="2026-01-01", end_date="2026-08-01", level="repo", community="demo", source="github",
+        json_file="repos.json", model_name="Demo Model",
+        metrics_weights_thresholds={first_metric: {"weight": 1, "threshold": 1}},
+    )
+    if model_cls is BaseMetricsModelV2:
+        kwargs["custom_fields"] = {"period": "month"}
+    return model_cls(**kwargs)
+
+
+class RepoLevelDispatchTest(unittest.TestCase):
+    """repo 级别的分发应互斥：一个模型只应走一条 enrich 管线。
+    修复前 if/if/else 级联导致命中 license/security（或 _year）分支的模型
+    额外再跑一遍周期 enrich 管线。"""
+
+    def test_security_metric_only_runs_version_pipeline_v2(self):
+        model = make_model(BaseMetricsModelV2, "security_binary_artifact")
+        model.metrics_model_enrich_year = MagicMock()
+        model.metrics_model_enrich_version = MagicMock()
+        model.metrics_model_enrich = MagicMock()
+
+        with patch("compass_model.base_metrics_model_v2.get_client", return_value=MagicMock()), \
+                patch("compass_model.base_metrics_model_v2.get_repo_list", return_value=["org/repo"]):
+            model.metrics_model_metrics("http://es:9200")
+
+        model.metrics_model_enrich_version.assert_called_once()
+        model.metrics_model_enrich_year.assert_not_called()
+        model.metrics_model_enrich.assert_not_called()
+
+    def test_period_metric_only_runs_period_pipeline_v2(self):
+        model = make_model(BaseMetricsModelV2, "comment_frequency")
+        model.metrics_model_enrich_year = MagicMock()
+        model.metrics_model_enrich_version = MagicMock()
+        model.metrics_model_enrich = MagicMock()
+
+        with patch("compass_model.base_metrics_model_v2.get_client", return_value=MagicMock()), \
+                patch("compass_model.base_metrics_model_v2.get_repo_list", return_value=["org/repo"]):
+            model.metrics_model_metrics("http://es:9200")
+
+        model.metrics_model_enrich.assert_called_once()
+        model.metrics_model_enrich_year.assert_not_called()
+        model.metrics_model_enrich_version.assert_not_called()
+
+    def test_year_metric_only_runs_year_pipeline_v2(self):
+        model = make_model(BaseMetricsModelV2, "issue_count_year")
+        model.metrics_model_enrich_year = MagicMock()
+        model.metrics_model_enrich_version = MagicMock()
+        model.metrics_model_enrich = MagicMock()
+
+        with patch("compass_model.base_metrics_model_v2.get_client", return_value=MagicMock()), \
+                patch("compass_model.base_metrics_model_v2.get_repo_list", return_value=["org/repo"]):
+            model.metrics_model_metrics("http://es:9200")
+
+        model.metrics_model_enrich_year.assert_called_once()
+        model.metrics_model_enrich_version.assert_not_called()
+        model.metrics_model_enrich.assert_not_called()
+
+    def test_security_metric_only_runs_version_pipeline_v1(self):
+        model = make_model(BaseMetricsModelV1, "security_vul_stat")
+        model.metrics_model_enrich_year = MagicMock()
+        model.metrics_model_enrich_version = MagicMock()
+        model.metrics_model_enrich = MagicMock()
+
+        with patch("compass_model.base_metrics_model.get_client", return_value=MagicMock()), \
+                patch("compass_model.base_metrics_model.get_repo_list", return_value=["org/repo"]):
+            model.metrics_model_metrics("http://es:9200")
+
+        model.metrics_model_enrich_version.assert_called_once()
+        model.metrics_model_enrich_year.assert_not_called()
+        model.metrics_model_enrich.assert_not_called()
+
+    def test_period_metric_only_runs_period_pipeline_v1(self):
+        model = make_model(BaseMetricsModelV1, "comment_frequency")
+        model.metrics_model_enrich_year = MagicMock()
+        model.metrics_model_enrich_version = MagicMock()
+        model.metrics_model_enrich = MagicMock()
+
+        with patch("compass_model.base_metrics_model.get_client", return_value=MagicMock()), \
+                patch("compass_model.base_metrics_model.get_repo_list", return_value=["org/repo"]):
+            model.metrics_model_metrics("http://es:9200")
+
+        model.metrics_model_enrich.assert_called_once()
+        model.metrics_model_enrich_year.assert_not_called()
+        model.metrics_model_enrich_version.assert_not_called()
+
+    def test_year_metric_only_runs_year_pipeline_v1(self):
+        model = make_model(BaseMetricsModelV1, "issue_count_year")
+        model.metrics_model_enrich_year = MagicMock()
+        model.metrics_model_enrich_version = MagicMock()
+        model.metrics_model_enrich = MagicMock()
+
+        with patch("compass_model.base_metrics_model.get_client", return_value=MagicMock()), \
+                patch("compass_model.base_metrics_model.get_repo_list", return_value=["org/repo"]):
+            model.metrics_model_metrics("http://es:9200")
+
+        model.metrics_model_enrich_year.assert_called_once()
+        model.metrics_model_enrich_version.assert_not_called()
+        model.metrics_model_enrich.assert_not_called()
+
+
+class CommunityLevelDispatchTest(unittest.TestCase):
+    def test_year_metric_does_not_also_run_period_pipeline_v2(self):
+        model = make_model(BaseMetricsModelV2, "issue_count_year")
+        model.level = "community"
+        model.metrics_model_enrich_year = MagicMock()
+        model.metrics_model_enrich_version = MagicMock()
+        model.metrics_model_enrich = MagicMock()
+
+        with patch("compass_model.base_metrics_model_v2.get_client", return_value=MagicMock()), \
+                patch("compass_model.base_metrics_model_v2.get_community_repo_list",
+                      return_value=(["org/sa-repo"], ["org/gov-repo"])):
+            model.metrics_model_metrics("http://es:9200")
+
+        model.metrics_model_enrich_year.assert_called_once()
+        model.metrics_model_enrich_version.assert_not_called()
+        model.metrics_model_enrich.assert_not_called()
+
+    def test_period_metric_runs_period_pipeline_v2(self):
+        model = make_model(BaseMetricsModelV2, "comment_frequency")
+        model.level = "community"
+        model.metrics_model_enrich_year = MagicMock()
+        model.metrics_model_enrich_version = MagicMock()
+        model.metrics_model_enrich = MagicMock()
+
+        with patch("compass_model.base_metrics_model_v2.get_client", return_value=MagicMock()), \
+                patch("compass_model.base_metrics_model_v2.get_community_repo_list",
+                      return_value=(["org/sa-repo"], ["org/gov-repo"])):
+            model.metrics_model_metrics("http://es:9200")
+
+        model.metrics_model_enrich_year.assert_not_called()
+        model.metrics_model_enrich_version.assert_not_called()
+        # software-artifact 与 governance 两个仓库集合各跑一次
+        self.assertEqual(model.metrics_model_enrich.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 缺陷

`compass_model/base_metrics_model.py` 与 `compass_model/base_metrics_model_v2.py` 的 `metrics_model_metrics` 用 `if / if / else` 级联选择 enrich 管线，而非互斥的 `if / elif / elif / else`：

```python
if '_year' in metric_field:
    self.metrics_model_enrich_year(...)
if 'license' in metric_field or 'security' in metric_field or 'activity_quarterly_' in metric_field:
    self.metrics_model_enrich_version(...)
if 'doc_' in metric_field or metric_field == 'org_contribution' or 'vul_' in metric_field:
    self.metrics_model_enrich_version(...)
else:
    self.metrics_model_enrich(...)   # ← 命中上面任一 if 的模型也会掉进这里
```

首个 metric 名包含 `license`/`security`（或 `_year`）的模型会**同时**走 version 管线和周期管线：

1. **重复计算与重复写库**：version 类指标本来是按版本一次性计算（`enrich_version`），周期管线会再把同样的无日期指标按每个周期重算一遍、按不同 uuid 重复写入 out_index；
2. **崩溃风险**：`metrics_model_enrich_version` 要求 `custom_fields['version_number']`（KeyError），一旦缺失，异常在周期管线产出任何结果之前就中断该 repo 的整个模型计算。

## 受影响的仓库内模型

`compass_model_v2/supply_chain_security/release_and_maintenance/release_quality_metrics_model.py`（Release Quality）首个 metric 为 `security_binary_artifact`，命中 `security` 分支 + 尾部 else，两条管线都会执行。

## 修复

v1/v2 两份基类、repo/community 两个层级统一改为 `if / elif / elif / else` 互斥分发。只命中单个分支的模型（仓库内现有的 8 个 v1 模型与绝大多数 v2 模型）行为完全不变。

## 测试

新增 `tests/test_metrics_model_dispatch.py`（8 个用例，mock 三条管线与 ES client）：security/year/周期三类首个 metric 在 v1、v2 下各自只触发对应管线；community 级别 year 模型不再额外跑周期管线、周期模型保持 sa/gov 两次调用。