### PR TITLE
fix: get_date_list_by_period 不支持文档声明的 day/week，未知 period 静默按月处理

### DIFF
--- a/compass_common/datetime.py
+++ b/compass_common/datetime.py
@@ -219,7 +219,7 @@ def get_date_list(begin_date, end_date, freq='W-MON'):
 def get_date_list_by_period(begin_date, end_date,period):
     '''
         根据 period 获取从 begin_date 到 end_date 的时间列表
-        period: 'day', 'week', 'month', 'year'
+        period: 'day', 'week', 'month', 'quarter', 'year'
         '''
 
     # 1. 定义 period 到 Pandas freq 的映射关系
@@ -227,10 +227,11 @@ def get_date_list_by_period(begin_date, end_date,period):
     # 'D': 每日
     # 'W-MON': 每周 (周一开始)
     # 'MS': 每月 (月初开始, Month Start) -> 注意：用 'M' 会是月末
+    # 'QS': 每季度 (季初开始, Quarter Start)
     # 'YS': 每年 (年初开始, Year Start)
-    print(f"period: {period}")
     freq_map = {
-
+        'day': 'D',
+        'week': 'W-MON',
         'month': 'MS',
         'quarter': 'QS',
         'year': 'YS'
@@ -238,10 +239,9 @@ def get_date_list_by_period(begin_date, end_date,period):
 
     # 2. 获取对应的 freq，如果没传或者找不到，默认设为 'W-MON' (按周)
     # 这里的 .get(period, 'W-MON') 意味着如果 period 是乱写的，就默认按周处理
-    freq = freq_map.get(period, 'MS')
+    freq = freq_map.get(period, 'W-MON')
 
-    # 3. 生成时间列表 (保留了你原有的转换逻辑)
-    # 建议直接用 .tolist()，比 [x for x in list(...)] 更快更简洁
+    # 3. 生成时间列表
     date_list = pd.date_range(
         freq=freq,
         start=datetime_to_utc(str_to_datetime(begin_date)),

--- a/tests/test_datetime_period_list.py
+++ b/tests/test_datetime_period_list.py
@@ -1,0 +1,35 @@
+import unittest
+
+from compass_common.datetime import get_date_list_by_period
+
+
+class GetDateListByPeriodTest(unittest.TestCase):
+    """get_date_list_by_period 的文档说明支持 'day' / 'week' / 'month' / 'year'，
+    且未知 period 应回退为每周（W-MON）。修复前 'day'/'week' 及未知值都会
+    静默按月（'MS'）生成，导致周期粒度错误。"""
+
+    def test_week_returns_mondays(self):
+        dates = get_date_list_by_period("2026-08-03", "2026-08-24", "week")
+        self.assertEqual(len(dates), 4)
+        for date in dates:
+            self.assertEqual(date.weekday(), 0)
+
+    def test_day_returns_daily_dates(self):
+        dates = get_date_list_by_period("2026-08-01", "2026-08-05", "day")
+        self.assertEqual(len(dates), 5)
+
+    def test_unknown_period_falls_back_to_weekly(self):
+        dates = get_date_list_by_period("2026-08-03", "2026-08-24", "fortnight")
+        self.assertEqual(len(dates), 4)
+
+    def test_month_still_returns_month_starts(self):
+        dates = get_date_list_by_period("2026-08-01", "2026-09-15", "month")
+        self.assertEqual([date.strftime("%Y-%m-%d") for date in dates], ["2026-08-01", "2026-09-01"])
+
+    def test_year_still_returns_year_starts(self):
+        dates = get_date_list_by_period("2025-01-01", "2026-03-01", "year")
+        self.assertEqual([date.strftime("%Y-%m-%d") for date in dates], ["2025-01-01", "2026-01-01"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 缺陷

`compass_common/datetime.py` 的 `get_date_list_by_period`：

- docstring 声明支持 `period: 'day', 'week', 'month', 'year'`，但 `freq_map` 只有 `month/quarter/year` —— `'day'`、`'week'` 都会静默落进默认值；
- 代码内注释写明"如果 period 是乱写的，就默认按周处理（'W-MON'）"，但实际默认值是 `'MS'`（按月）——**代码与自己的注释直接矛盾**。

后果：任何传入 `'week'`/`'day'`（或拼写错误的 period）的调用方都会拿到**按月**的时间列表，周期粒度静默变错。该函数被 v2 `metrics_model_enrich` 用于生成周期循环，而周期值来自外部服务传入的 `custom_fields['period']`。

## 稳定复现

```python
from compass_common.datetime import get_date_list_by_period
get_date_list_by_period("2026-08-03", "2026-08-24", "week")
# 修复前: 1 个点（按月）   修复后: 4 个周一
get_date_list_by_period("2026-08-01", "2026-08-05", "day")
# 修复前: 1 个点（按月）   修复后: 5 个点
```

## 修复

补齐 `'day': 'D'`、`'week': 'W-MON'` 映射，默认值改为与注释一致的 `'W-MON'`（v1 enrich 的既有节奏就是每周一）；顺带移除该函数内的调试 `print`。`month/quarter/year` 行为不变。

## 测试

新增 `tests/test_datetime_period_list.py`（5 个用例）：week 返回周一序列、day 返回逐日、未知 period 回退按周、month/year 行为保持不变。