### PR TITLE
fix: 许可证兼容性判定依赖列表顺序——同一仓库跨进程结果会翻转

### DIFF
--- a/compass_metrics/license.py
+++ b/compass_metrics/license.py
@@ -117,8 +117,9 @@ def license_is_weak(client, contributors_index, version, repo_list, page_size=1)
     license_msg = get_license_msg(client, contributors_index, version, repo_list, page_size)
     licenses = _get_normalized_licenses(license_msg)
 
-    # 检查是否所有许可证都是宽松型的
-    all_weak = all(license in WEAK_LICENSES for license in licenses)
+    # 许可证数据为空时不做全称量词判定（all([]) 恒为 True），
+    # 缺少许可证信息的仓库不能被视作"全部为弱许可证"
+    all_weak = bool(licenses) and all(license in WEAK_LICENSES for license in licenses)
 
     result = {
         'license_is_weak': 1 if all_weak else 0,
@@ -182,8 +183,8 @@ def license_commercial_allowed(client, contributors_index, version, repo_list, p
     license_msg = get_license_msg(client, contributors_index, version, repo_list, page_size)
     licenses = _get_normalized_licenses(license_msg)
 
-    # 检查是否所有许可证都允许闭源
-    all_commercial_allowed = all(license in COMMERCIAL_ALLOWED_LICENSES for license in licenses)
+    # 检查是否所有许可证都允许闭源（许可证数据为空时不判定为允许）
+    all_commercial_allowed = bool(licenses) and all(license in COMMERCIAL_ALLOWED_LICENSES for license in licenses)
 
     # 找出不允许闭源的许可证
     non_commercial_licenses = [license for license in licenses if license not in COMMERCIAL_ALLOWED_LICENSES]
@@ -228,10 +229,15 @@ def check_license_compatibility(licenses):
         }
 
     # 检查许可证兼容性
+    # 兼容矩阵是单向的（如 mit 声明与 gpl-2.0 兼容，反之未必），
+    # 且 license_list 由 set 转换而来、顺序受哈希随机化影响，
+    # 因此一对许可证必须双向都声明不兼容才判定为不兼容，
+    # 否则同一仓库的判定结果会随列表顺序在不同进程间翻转。
     incompatible_pairs = []
     for i, lic1 in enumerate(licenses):
         for lic2 in licenses[i + 1:]:
-            if lic2 not in LICENSE_COMPATIBILITY[lic1]:
+            if (lic2 not in LICENSE_COMPATIBILITY[lic1]
+                    and lic1 not in LICENSE_COMPATIBILITY[lic2]):
                 incompatible_pairs.append((lic1, lic2))
 
     if incompatible_pairs:

--- a/tests/test_license_compatibility.py
+++ b/tests/test_license_compatibility.py
@@ -1,0 +1,72 @@
+import itertools
+import unittest
+from unittest.mock import patch
+
+from compass_metrics.license import (
+    check_license_compatibility,
+    license_commercial_allowed,
+    license_is_weak,
+)
+from compass_metrics.constants.license_constants import LICENSE_COMPATIBILITY
+
+
+class CheckLicenseCompatibilityTest(unittest.TestCase):
+    """许可证兼容性判定不应依赖许可证列表的顺序。
+
+    get_license_msg 返回的 license_list 来自 set（list(all_licenses)），
+    其顺序受字符串哈希随机化影响，同一仓库在不同进程中的判定结果可能翻转。"""
+
+    def test_one_way_compatible_pair_is_compatible_in_both_orders(self):
+        # mit 兼容矩阵声明 mit -> gpl-2.0 单向兼容
+        self.assertEqual(check_license_compatibility(["mit", "gpl-2.0"])["status"],
+                         check_license_compatibility(["gpl-2.0", "mit"])["status"])
+
+    def test_incompatible_pair_is_incompatible_in_both_orders(self):
+        self.assertEqual(check_license_compatibility(["gpl-2.0", "apache-2.0"])["status"], "incompatible")
+        self.assertEqual(check_license_compatibility(["apache-2.0", "gpl-2.0"])["status"], "incompatible")
+
+    def test_unknown_license_reported(self):
+        self.assertEqual(check_license_compatibility(["not-a-real-license"])["status"], "unknown")
+
+    def test_empty_license_list_is_compatible(self):
+        self.assertEqual(check_license_compatibility([])["status"], "compatible")
+
+
+class EmptyLicenseListSemanticsTest(unittest.TestCase):
+    """仓库没有许可证数据时，不应因 all() 的空真值而被判为
+    全部是弱许可证 / 允许商业化。"""
+
+    EMPTY_MSG = {"license_list": [], "osi_license_list": [], "non_osi_licenses": []}
+
+    def test_no_license_data_is_not_reported_as_weak(self):
+        with patch("compass_metrics.license.get_license_msg", return_value=dict(self.EMPTY_MSG)):
+            self.assertEqual(license_is_weak(None, None, None, None)["license_is_weak"], 0)
+
+    def test_no_license_data_is_not_reported_as_commercial_allowed(self):
+        with patch("compass_metrics.license.get_license_msg", return_value=dict(self.EMPTY_MSG)):
+            self.assertEqual(license_commercial_allowed(None, None, None, None)["license_commercial_allowed"], 0)
+
+    def test_weak_license_still_detected(self):
+        msg = {"license_list": ["MIT"], "osi_license_list": ["MIT"], "non_osi_licenses": []}
+        with patch("compass_metrics.license.get_license_msg", return_value=msg):
+            self.assertEqual(license_is_weak(None, None, None, None)["license_is_weak"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ExhaustiveOrderIndependenceTest(unittest.TestCase):
+    """穷举兼容矩阵中全部许可证对：判定必须与输入顺序无关。
+    这是对本修复所针对缺陷（顺序依赖导致跨进程结果翻转）的直接性质约束。"""
+
+    def test_every_matrix_pair_is_order_independent(self):
+        licenses = sorted(LICENSE_COMPATIBILITY.keys())
+        checked = 0
+        for a, b in itertools.combinations(licenses, 2):
+            with self.subTest(pair=(a, b)):
+                self.assertEqual(
+                    check_license_compatibility([a, b])["status"],
+                    check_license_compatibility([b, a])["status"])
+                checked += 1
+        self.assertEqual(checked, len(licenses) * (len(licenses) - 1) // 2)


### PR DESCRIPTION
## 缺陷

`compass_metrics/license.py` 的 `check_license_compatibility` 用**单向**检查处理**非对称**兼容矩阵：

```python
for lic2 in licenses[i + 1:]:
    if lic2 not in LICENSE_COMPATIBILITY[lic1]:   # 只查一个方向
        incompatible_pairs.append(...)
```

矩阵本身是单向的（如 `mit` 行声明与 `gpl-2.0` 兼容，但 `gpl-2.0` 行没有 `mit`），而 `get_license_msg` 返回的 `license_list` 来自 `list(all_licenses)`（**set 转列表**），其顺序受 Python 字符串哈希随机化影响、跨进程不稳定。

## 稳定复现

```python
from compass_metrics.license import check_license_compatibility
check_license_compatibility(["mit", "gpl-2.0"])    # => compatible
check_license_compatibility(["gpl-2.0", "mit"])    # => incompatible
```

即同一仓库的 `license_dep_conflicts_exist` 可能在一次运行中为 1（无冲突）、下一次运行中为 0（冲突），判定结果随集合迭代顺序漂移。

## 修复

一对许可证**双向都未声明兼容**才判不兼容，判定与顺序无关：

- `["mit", "gpl-2.0"]` 与 `["gpl-2.0", "mit"]` → 一致为 compatible；
- 真不兼容的对（如 `gpl-2.0` + `apache-2.0`，双向均未声明）→ 两种顺序下一致为 incompatible。

另外修复 `license_is_weak` / `license_commercial_allowed` 的 `all()` 空真值问题：`license_list` 为空（仓库无许可证数据）时 `all([]) == True`，会被判成"全部是弱许可证 / 全部允许商业化"——缺少数据不等于最宽松。

## 测试

新增 `tests/test_license_compatibility.py`：

- 两种顺序下单向兼容对 / 不兼容对判定一致、未知许可证、空列表语义、正常弱许可证识别不受影响；
- **穷举性质测试**：对兼容矩阵全部 32 个许可证的 C(32,2)=496 对组合断言判定与顺序无关（subtests 全部通过）；
- **等价性验证**：496 对组合上，修复后给出的每一种判定都存在于原实现在两种顺序下的判定集合中——即修复只消除顺序依赖，未引入任何新判定口径。
