### PR TITLE
fix: pip install 后的发行包缺失大部分 v2 代码（find_packages 漏掉全部命名空间包）

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import re
 
 # Always prefer setuptools over distutils
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 
 setup(name="compass_metrics_model",
@@ -22,7 +22,12 @@ setup(name="compass_metrics_model",
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5'],
       keywords="Metric Model",
-      packages=find_packages(),
+      # 仓库内大量包目录（compass_metrics_v2、compass_model_v2 的子包、
+      # compass_metrics/constants、compass_model 的子包等）没有 __init__.py，
+      # 属于 PEP 420 命名空间包，必须用 find_namespace_packages 才能打进发行包
+      packages=find_namespace_packages(include=['compass_common*', 'compass_contributor*',
+                                                'compass_metrics*', 'compass_model*',
+                                                'compass_prediction*']),
       package_data={
           'compass_metrics_model': ['resources/*'],
           'compass_metrics': ['resources/*'],

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,47 @@
+import os
+import unittest
+
+from setuptools import find_namespace_packages
+
+# 与 setup.py 中保持一致的发现范围
+INCLUDE = ["compass_common*", "compass_contributor*", "compass_metrics*", "compass_model*", "compass_prediction*"]
+SKIP_DIRS = {"__pycache__", "build", ".git", ".venv", "node_modules"}
+
+
+def source_packages():
+    """收集仓库中所有包含 .py 文件的 compass_* 目录（不含数据目录）。"""
+    found = set()
+    for root, dirs, files in os.walk("."):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS and not d.endswith(".egg-info")]
+        rel = os.path.relpath(root, ".")
+        if rel == ".":
+            continue
+        if not rel.split(os.sep)[0].split("-")[0].startswith("compass_"):
+            continue
+        if any(f.endswith(".py") for f in files):
+            found.add(rel.replace(os.sep, "."))
+    return found
+
+
+class PackagingTest(unittest.TestCase):
+    """pip install 后的发行包必须包含全部源码包。
+
+    find_packages() 只识别带 __init__.py 的目录，仓库内大量 PEP 420
+    命名空间包（compass_metrics_v2、compass_model_v2 的全部子包、
+    compass_metrics/constants、compass_model 的子包等）会被整包遗漏，
+    导致 pip install 后 import compass_metrics_v2 直接失败。"""
+
+    def test_discovery_covers_every_source_package(self):
+        packages = set(find_namespace_packages(include=INCLUDE))
+        missing = source_packages() - packages
+        self.assertEqual(missing, set(), f"未被打包的源码包: {sorted(missing)}")
+
+    def test_setup_uses_namespace_package_discovery(self):
+        with open("setup.py", encoding="utf-8") as f:
+            setup_src = f.read()
+        self.assertIn("find_namespace_packages", setup_src)
+        self.assertNotIn("packages=find_packages()", setup_src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 缺陷

`setup.py` 使用 `find_packages()`，它只识别**带 `__init__.py`** 的目录。仓库内大量目录是 PEP 420 命名空间包（无 `__init__.py`）：

- `compass_metrics_v2/`（整个 v2 指标层）
- `compass_model_v2/` 的全部子包（supply_chain_security / community_health / developer_journey 下的 27 个模型文件）
- `compass_model/` 的全部子包（collaboration / contributor / lab / software_artifact，含 ActivityMetricsModel、ScorecardMetricsModel、CriticalityScoreMetricsModel 等）
- `compass_metrics/constants/`（license_constants / security_constants）
- `compass_prediction/`

在仓库根目录直接运行入口脚本时靠命名空间包机制掩盖了问题；一旦 `pip install .`，安装出的发行包是**残缺的**。实际构建 wheel 验证：

```
修复前                                   修复后
compass_metrics_v2/          0 个文件     7 个 py 文件
compass_model_v2/            2 个文件     29 个 py 文件
compass_model/collaboration/ 0 个文件     5 个 py 文件
compass_model/software_artifact/ 0 个     2 个 py 文件
compass_metrics/constants/   0 个文件     2 个 py 文件
合计                         61 个文件    109 个文件
```

安装后 `import compass_metrics_v2` 直接 ModuleNotFoundError；`import compass_metrics.security` 因 `compass_metrics.constants` 缺失同样失败——v2 模型体系在 pip 安装环境下完全不可用。

## 修复

`find_packages()` → `find_namespace_packages(include=['compass_common*', 'compass_contributor*', 'compass_metrics*', 'compass_model*', 'compass_prediction*'])`，include 过滤避免误收 `tools/`、`build/` 等非包目录。

## 测试

新增 `tests/test_packaging.py`：遍历仓库所有含 `.py` 的 `compass_*` 目录，断言包发现结果全覆盖（回归测试）；并断言 setup.py 使用命名空间包发现。