### PR TITLE
fix: 无安全扫描数据时的触发扫描请求发送非法 project_url，从未生效

### DIFF
--- a/compass_metrics/security.py
+++ b/compass_metrics/security.py
@@ -46,7 +46,11 @@ def get_security_msg(client, contributors_index, version, repo_list, page_size, 
     security_msg = get_all_index_data(client, index=contributors_index, body=query)
 
     if not security_msg:
-        get_license(repo_list, version)
+        # 逐仓库触发扫描：get_license 内部按单个仓库地址拼接
+        # project_url（f"{repo}.git"），传入整个 repo_list 会生成
+        # "['org/a', 'org/b'].git" 这样的非法地址，导致触发永远失败
+        for repo_url in repo_list:
+            get_license(repo_url, version)
         return []
 
     results = []

--- a/tests/test_security_scan_trigger.py
+++ b/tests/test_security_scan_trigger.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import patch
+
+from compass_metrics import security
+
+
+class TriggerScanForMissingDataTest(unittest.TestCase):
+    """仓库缺少安全扫描数据时应触发 opencheck 扫描，且 project_url
+    必须是单个仓库地址（f"{repo}.git"），而不是把 repo_list 整个列表
+    f-string 成 "['org/a', 'org/b'].git" 这样的非法 URL。"""
+
+    def test_scan_triggered_per_repo_with_valid_project_url(self):
+        post_calls = []
+
+        def fake_post(request_path, payload, token=None):
+            post_calls.append((request_path, payload))
+            if request_path == "auth":
+                return {"status": True, "body": {"access_token": "tok"}}
+            return {"status": True, "body": {}}
+
+        with patch("compass_metrics.license.get_all_index_data", return_value=[]), \
+                patch("compass_metrics.security.get_all_index_data", return_value=[]), \
+                patch("compass_metrics.security.base_post_request", side_effect=fake_post):
+            result = security.get_security_msg(
+                client=None, contributors_index="opencheck-idx", version="v1",
+                repo_list=["org/repo-a", "org/repo-b"], page_size=1)
+
+        self.assertEqual(result, [])  # 无数据时返回空，由触发扫描兜底
+        scan_calls = [payload for path, payload in post_calls if path == "opencheck"]
+        self.assertEqual(
+            sorted(payload["project_url"] for payload in scan_calls),
+            ["org/repo-a.git", "org/repo-b.git"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 缺陷

`compass_metrics/security.py` 的 `get_security_msg` 在查不到扫描数据时会触发 opencheck 扫描：

```python
if not security_msg:
    get_license(repo_list, version)   # repo_list 是列表
    return []
```

而 `get_license(repo, version)` 内部按**单个仓库**拼接地址：

```python
payload = {
    ...
    "project_url": f"{repo}.git",
    ...
}
```

传入整个列表后，实际发给 opencheck 服务的 project_url 是：

```
"['org/repo-a', 'org/repo-b'].git"
```

服务端不可能匹配到任何真实仓库——"查不到数据就触发扫描"这条兜底路径**从未生效过**，且每次都向服务发送无效任务。

## 修复

逐仓库触发：`for repo_url in repo_list: get_license(repo_url, version)`，project_url 恢复为 `f"{repo}.git"` 的预期格式。

## 测试

新增 `tests/test_security_scan_trigger.py`：mock 全部 HTTP 调用，捕获 POST payload，断言每个仓库各触发一次扫描且 project_url 形如 `org/repo-a.git`（修复前为列表字符串）。