### PR TITLE
fix: scroll 辅助函数的异常处理自身会抛 AttributeError

### DIFF
--- a/compass_common/opensearch_utils.py
+++ b/compass_common/opensearch_utils.py
@@ -147,7 +147,9 @@ def get_items(client, index, body, size, scroll_id=None, scroll="5m"):
         else:
             page = client.scroll(scroll_id=scroll_id, scroll=scroll)
     except Exception as e:
-        if too_many_scrolls(e.info):
+        # 非 ES 传输类异常没有 info 属性，直接访问会抛 AttributeError
+        # 并掩盖原始异常
+        if too_many_scrolls(getattr(e, "info", None)):
             return {'too_many_scrolls': True}
     return page
 
@@ -171,5 +173,5 @@ def free_scroll(client, scroll_id=None):
         return
     try:
         client.clear_scroll(scroll_id=scroll_id)
-    except Exception as e:
-        logger.debug("Error releasing scroll: {}".scroll_id)
+    except Exception:
+        logger.debug("Error releasing scroll: {}".format(scroll_id))

--- a/tests/test_opensearch_utils_scroll.py
+++ b/tests/test_opensearch_utils_scroll.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import MagicMock
+
+from compass_common.opensearch_utils import free_scroll, get_items
+
+
+class FreeScrollTest(unittest.TestCase):
+    """clear_scroll 失败时应记录 debug 日志后返回，
+    而不是因日志语句自身的 "{}" .scroll_id 属性错误抛 AttributeError。"""
+
+    def test_clear_scroll_failure_is_logged_not_raised(self):
+        client = MagicMock()
+        client.clear_scroll.side_effect = RuntimeError("boom")
+        free_scroll(client, "scroll-abc")  # 修复前：AttributeError
+
+    def test_clear_scroll_success_noop(self):
+        client = MagicMock()
+        free_scroll(client, "scroll-abc")
+        client.clear_scroll.assert_called_once_with(scroll_id="scroll-abc")
+
+
+class GetItemsTest(unittest.TestCase):
+    """search 抛出非 ES 传输类异常时不应在 except 分支里访问 e.info
+    导致二次异常（AttributeError）掩盖原始错误。"""
+
+    def test_non_transport_exception_returns_none_without_masking(self):
+        client = MagicMock()
+        client.search.side_effect = KeyError("bad body")
+        self.assertIsNone(get_items(client, "idx", {"query": {}}, 10))
+
+    def test_es_error_without_too_many_scrolls_returns_none(self):
+        class FakeTransportError(Exception):
+            info = {"status": 400, "error": {"root_cause": [{"reason": "other failure"}]}}
+
+        client = MagicMock()
+        client.search.side_effect = FakeTransportError("x")
+        self.assertIsNone(get_items(client, "idx", {"query": {}}, 10))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 缺陷

`compass_common/opensearch_utils.py` 两个滚动查询辅助函数的异常处理存在缺陷：

### 1. free_scroll：日志语句写错，清理失败即崩溃

```python
except Exception as e:
    logger.debug("Error releasing scroll: {}".scroll_id)   # 对字符串取属性！
```

`"{}".scroll_id` 是属性访问而非 `.format(scroll_id)`，因此 `clear_scroll` 一旦失败（网络抖动、客户端已关闭等），本应"记条 debug 日志继续"的清理逻辑自己抛出 `AttributeError`，**直接中断正在运行的指标计算任务**。

### 2. get_items：非 ES 异常被二次异常掩盖

```python
except Exception as e:
    if too_many_scrolls(e.info):   # 非 ES 传输类异常没有 info 属性
        return {'too_many_scrolls': True}
```

`except Exception` 捕获所有异常后一律访问 `e.info`——任何非 ES 传输类异常（如查询体构造错误的 KeyError）都会在处理器内再抛 `AttributeError`，掩盖并替换原始错误，增加排查难度。

## 修复

- `logger.debug("Error releasing scroll: {}".format(scroll_id))`
- `too_many_scrolls(getattr(e, "info", None))`——ES 传输异常行为不变（`too_many_scrolls(None)` 为 False），非 ES 异常不再二次爆炸。

## 测试

新增 `tests/test_opensearch_utils_scroll.py`（4 个用例）：clear_scroll 失败不再抛出、成功路径仍调用 clear_scroll、非 ES 异常返回 None 不掩盖、带 info 的 ES 异常行为保持。