### PR TITLE
fix: 干净安装 requirements.txt 后模型包无法导入（依赖声明与实际 import 对齐）

### DIFF
--- a/compass_metrics/document_metric/doc_chinese_support.py
+++ b/compass_metrics/document_metric/doc_chinese_support.py
@@ -18,7 +18,6 @@ import os
 import re
 import json
 import requests
-from git import Repo
 from compass_metrics.document_metric.utils import GITHUB_TOKEN,GITEE_TOKEN,TMP_PATH,JSON_REPOPATH
 from compass_metrics.document_metric.utils import load_json,check_github_gitee,clone_repo,save_json
 

--- a/compass_metrics/document_metric/utils.py
+++ b/compass_metrics/document_metric/utils.py
@@ -10,7 +10,6 @@ import json
 import os
 import sys
 import requests
-import tqdm
 import markdown
 DATA_PATH = "/data"
 NOW_PATH =  os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/compass_metrics/security_metric/utils.py
+++ b/compass_metrics/security_metric/utils.py
@@ -10,7 +10,6 @@ import json
 import os
 import sys
 import requests
-import tqdm
 import markdown
 # from compass_metrics.resources.config.ini import GITEE_TOKEN, GITHUB_TOKEN
 DATA_PATH = r"/data"

--- a/compass_metrics/utils_code_readability.py
+++ b/compass_metrics/utils_code_readability.py
@@ -10,7 +10,6 @@ import json
 import os
 import sys
 import requests
-import tqdm
 import markdown
 import configparser
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ python_dateutil==2.8.2
 PyYAML==6.0.1
 setuptools==59.6.0
 urllib3==1.26.5
+requests==2.31.0
+markdown==3.4.3
+apscheduler==3.10.4


### PR DESCRIPTION
## 缺陷（运行环境）

在全新的 Python 3.8 环境中执行 `pip install -r requirements.txt` 后：

```text
import compass_model.base_metrics_model
  -> ModuleNotFoundError: requests   # 依次还会缺 tqdm、markdown、git
import run_scheduler_task
  -> ModuleNotFoundError: apscheduler
```

即按仓库声明的依赖装完环境后，**两个基模型包与月度调度入口脚本都无法导入**（v1/v2 全部模型不可用）。

## 修复

**补充声明真实使用的依赖**（新增 3 项，不动既有 pin）：
- `requests==2.31.0`：9 个文件直接 import（activity/security/document_metric/utils_code_readability 等）；elasticsearch 6.3.1 并不传递依赖它
- `markdown==3.4.3`：`document_metric/utils.py` 调用 `markdown.markdown(...)`
- `apscheduler==3.10.4`：`run_scheduler_task.py` 的 BlockingScheduler/CronTrigger

**移除 4 个从未使用的死 import**（它们是干净安装失败的原因之一，但不新增对应依赖）：
- `import tqdm` ×3（utils_code_readability.py、document_metric/utils.py、security_metric/utils.py）——全仓库没有任何 `tqdm.` 调用
- `from git import Repo`（document_metric/doc_chinese_support.py）——Repo 未被使用

tqdm/GitPython 只在 import 行出现，删除后无需声明依赖。

## 验证

干净 venv（py3.8）+ 仅 `pip install -r requirements.txt`：
- 修复前：`import compass_model.base_metrics_model` 失败（requests → tqdm → markdown → git 逐个补装才能通过）
- 修复后：两个基模型包与 `run_scheduler_task` 全部导入成功