### PR TITLE
feat: 模型构造时快速失败校验 metric 配置（避免长跑后因配置笔误中断）

### DIFF
--- a/compass_model/base_metrics_model.py
+++ b/compass_model/base_metrics_model.py
@@ -312,12 +312,18 @@ class BaseMetricsModel:
             default_metrics_thresholds = self.get_default_metrics_thresholds()
             for metrics, weights_thresholds in metrics_weights_thresholds.items():
                 if weights_thresholds["threshold"] is None:
+                    if metrics not in default_metrics_thresholds:
+                        raise Exception(
+                            "No default threshold configured for metric '%s' at level '%s'. "
+                            "Set the threshold explicitly or add it to compass_metrics/resources/thresholds.yaml"
+                            % (metrics, self.level))
                     weights_thresholds["threshold"] = default_metrics_thresholds[metrics]
                 weights_thresholds["weight"] = abs(weights_thresholds["weight"])
                 if metrics in NEGATICE_METRICS:
                     weights_thresholds["weight"] = -weights_thresholds["weight"]
             self.metrics_weights_thresholds = metrics_weights_thresholds
             self.metrics_weights_thresholds_hash = get_dict_hash(metrics_weights_thresholds)
+            self.validate_metrics_config()
         else:
             raise Exception("Invalid metrics param.")
 
@@ -328,6 +334,14 @@ class BaseMetricsModel:
             self.custom_fields = {}
             self.custom_fields_hash = None
     
+
+    def validate_metrics_config(self):
+        """Fail fast on unknown metric names instead of raising
+        a generic "Invalid metric" midway through enrichment."""
+        known_metrics = set(self._metrics_switch(None, []).keys())
+        unknown_metrics = sorted(set(self.metrics_weights_thresholds.keys()) - known_metrics)
+        if unknown_metrics:
+            raise Exception("Invalid metric: %s" % ", ".join(unknown_metrics))
 
     def get_default_metrics_thresholds(self):
         """ Get default thresholds for metrics """
@@ -608,9 +622,9 @@ class BaseMetricsModel:
                     item_datas = []
             helpers().bulk(client=self.client, actions=item_datas)
 
-    def get_metrics(self, date, repo_list):
+    def _metrics_switch(self, date, repo_list):
         """ Get the corresponding metrics data according to the metrics field """
-        metrics_switch = {
+        return {
             # git metadata
             "commit_frequency": lambda: commit_frequency(self.client, self.contributors_index, date, repo_list),
             "commit_frequency_last_year": lambda: commit_frequency_last_year(self.client, self.contributors_index, date, repo_list),
@@ -747,8 +761,8 @@ class BaseMetricsModel:
             "dependency_update_tool": lambda: dependency_update_tool(self.client, self.openchecker_index, repo_list),
         }
 
-        
-        
+    def get_metrics(self, date, repo_list):
+        metrics_switch = self._metrics_switch(date, repo_list)
         metrics = {}
         metric_list = {}
         for metric_field in self.metrics_weights_thresholds.keys():

--- a/compass_model/base_metrics_model_v2.py
+++ b/compass_model/base_metrics_model_v2.py
@@ -424,12 +424,18 @@ class BaseMetricsModel:
             default_metrics_thresholds = self.get_default_metrics_thresholds()
             for metrics, weights_thresholds in metrics_weights_thresholds.items():
                 if weights_thresholds["threshold"] is None:
+                    if metrics not in default_metrics_thresholds:
+                        raise Exception(
+                            "No default threshold configured for metric '%s' at level '%s'. "
+                            "Set the threshold explicitly or add it to compass_metrics/resources/thresholds.yaml"
+                            % (metrics, self.level))
                     weights_thresholds["threshold"] = default_metrics_thresholds[metrics]
                 weights_thresholds["weight"] = abs(weights_thresholds["weight"])
                 if metrics in NEGATICE_METRICS:
                     weights_thresholds["weight"] = -weights_thresholds["weight"]
             self.metrics_weights_thresholds = metrics_weights_thresholds
             self.metrics_weights_thresholds_hash = get_dict_hash(metrics_weights_thresholds)
+            self.validate_metrics_config()
         else:
             raise Exception("Invalid metrics param.")
 
@@ -442,6 +448,14 @@ class BaseMetricsModel:
             self.custom_fields_hash = None
 
 
+
+    def validate_metrics_config(self):
+        """Fail fast on unknown metric names instead of raising
+        a generic "Invalid metric" midway through enrichment."""
+        known_metrics = set(self._metrics_switch(None, [], getattr(self, 'period', None) or 'month').keys())
+        unknown_metrics = sorted(set(self.metrics_weights_thresholds.keys()) - known_metrics)
+        if unknown_metrics:
+            raise Exception("Invalid metric: %s" % ", ".join(unknown_metrics))
 
     def get_default_metrics_thresholds(self):
         """ Get default thresholds for metrics """
@@ -728,8 +742,9 @@ class BaseMetricsModel:
                     item_datas = []
             helpers().bulk(client=self.client, actions=item_datas)
 
-    def get_metrics(self, date, repo_list, period='month'):
-        metrics_switch = {
+    def _metrics_switch(self, date, repo_list, period='month'):
+        """ Get the corresponding metrics data according to the metrics field """
+        return {
             # git metadata
             "commit_frequency": lambda: commit_frequency(self.client, self.contributors_index, date, repo_list),
             "commit_frequency_last_year": lambda: commit_frequency_last_year(self.client, self.contributors_index, date, repo_list),
@@ -997,10 +1012,9 @@ class BaseMetricsModel:
 
 
         }
-        """ Get the corresponding metrics data according to the metrics field """
 
-
-
+    def get_metrics(self, date, repo_list, period='month'):
+        metrics_switch = self._metrics_switch(date, repo_list, period)
         metrics = {}
         metric_list = {}
         for metric_field in self.metrics_weights_thresholds.keys():

--- a/tests/test_metrics_config_validation.py
+++ b/tests/test_metrics_config_validation.py
@@ -1,0 +1,55 @@
+import unittest
+
+from compass_model.base_metrics_model import BaseMetricsModel as BaseMetricsModelV1
+from compass_model.base_metrics_model_v2 import BaseMetricsModel as BaseMetricsModelV2
+
+
+def base_kwargs():
+    return dict(
+        repo_index="repo-idx", git_index="git-idx", issue_index="issue-idx", pr_index="pr-idx",
+        issue_comments_index="issue-cmt-idx", pr_comments_index="pr-cmt-idx",
+        contributors_index="contributor-idx", release_index="release-idx", out_index="out-idx",
+        from_date="2026-01-01", end_date="2026-08-01", level="repo", community="demo", source="github",
+        json_file="repos.json", model_name="Demo Model",
+    )
+
+
+class FailFastMetricValidationTest(unittest.TestCase):
+    """未知的 metric 名称应在模型构造时立即报错并点名具体指标，
+    而不是等 add_release_message / 周期富集开始后才抛出笼统的
+    "Invalid metric"，导致一次运行在消耗大量计算后失败。"""
+
+    def test_unknown_metric_fails_at_construction_v2(self):
+        with self.assertRaises(Exception) as ctx:
+            BaseMetricsModelV2(
+                metrics_weights_thresholds={"totally_unknown_metric": {"weight": 1, "threshold": 1}},
+                custom_fields={"period": "month"}, **base_kwargs())
+        self.assertIn("totally_unknown_metric", str(ctx.exception))
+
+    def test_unknown_metric_fails_at_construction_v1(self):
+        with self.assertRaises(Exception) as ctx:
+            BaseMetricsModelV1(
+                metrics_weights_thresholds={"totally_unknown_metric": {"weight": 1, "threshold": 1}},
+                **base_kwargs())
+        self.assertIn("totally_unknown_metric", str(ctx.exception))
+
+    def test_missing_default_threshold_names_metric_and_level_v2(self):
+        # binary_artifacts 是合法指标，但 thresholds.yaml 中没有它的默认阈值，
+        # threshold 传 None 时应给出明确报错而不是裸 KeyError
+        with self.assertRaises(Exception) as ctx:
+            BaseMetricsModelV2(
+                metrics_weights_thresholds={"binary_artifacts": {"weight": 1, "threshold": None}},
+                custom_fields={"period": "month"}, **base_kwargs())
+        message = str(ctx.exception)
+        self.assertIn("binary_artifacts", message)
+        self.assertIn("repo", message)
+
+    def test_valid_metric_config_still_constructs(self):
+        model = BaseMetricsModelV2(
+            metrics_weights_thresholds={"comment_frequency": {"weight": 1, "threshold": 15}},
+            custom_fields={"period": "month"}, **base_kwargs())
+        self.assertEqual(model.metrics_weights_thresholds["comment_frequency"]["threshold"], 15)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 特性（增加特性 / 代码增强）

当前 metric 配置里的未知指标名只有在 `get_metrics()` 执行时才抛出笼统的 `Exception("Invalid metric")`——即 `add_release_message` 之后、周期富集循环**已经开始**时。一个配置笔误会浪费大量计算后才让整个运行中断（外部服务按 repo/模型批量跑时影响放大）。

## 改动

1. **switch 构建逻辑提取为 `_metrics_switch()`**（v1/v2 各一处，纯机械搬移，字典内容零改动）；
2. `__init__` 末尾新增 `validate_metrics_config()`：配置中的每个 metric 名都必须存在于 switch，否则**构造阶段立即失败**并点名具体指标：
   ```text
   Invalid metric: totally_unknown_metric
   ```
3. `threshold: None` 且 yaml 无默认阈值时，之前抛裸 `KeyError: 'xxx'`，现在明确报出指标名与 level，并提示设置显式阈值或补充 thresholds.yaml。

## 兼容性

- switch 字典为逐行原样搬移，全部合法指标名行为不变；
- 仓库内所有既有模型（8 个 v1 + 27 个 v2）的 metric 名均在 switch 中，构造行为不变（现有 51 个测试全部通过）。

## 测试

新增 `tests/test_metrics_config_validation.py`（4 个用例）：未知指标 v1/v2 构造即报错且含指标名、缺失默认阈值报错含指标名与 level、合法配置照常构造。