### PR TITLE
fix: skip 3/4-week contributor rule for short analysis windows

### DIFF
--- a/compass_metrics/contributor_metrics.py
+++ b/compass_metrics/contributor_metrics.py
@@ -468,8 +468,6 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
             or the group that contributes 3/4 of the time in this timeframe (excluding star and fork contributions).
         """
         date_list = [x for x in list(pd.date_range(freq='W-MON', start=from_date, end=date))]
-        if len(date_list) >= 4:
-            weeks = len(date_list) * 3 / 4
         contribution_count_dict = {k: v["contribution_without_observe"] for k, v in contributor_dict.items()}
         sorted_dict = {k: v for k, v in
                         sorted(contribution_count_dict.items(), key=lambda item: item[1], reverse=True)}
@@ -481,9 +479,11 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
             result_contributor[k] = {**contributor_dict[k], "mileage_type": "regular"}
             if current_sum >= target_sum:
                 break
-        for k, v in contributor_dict.items():
-            if v["contribution_weeks"] >= weeks:
-                result_contributor[k] = {**v, "mileage_type": "regular"}
+        if len(date_list) >= 4:
+            weeks = len(date_list) * 3 / 4
+            for k, v in contributor_dict.items():
+                if v["contribution_weeks"] >= weeks:
+                    result_contributor[k] = {**v, "mileage_type": "regular"}
         core_name = core_contributor.keys()
         return {k: result_contributor[k] for k in result_contributor.keys() if k not in core_name}
 

--- a/compass_metrics_v2/contributor_metrics_v2.py
+++ b/compass_metrics_v2/contributor_metrics_v2.py
@@ -511,8 +511,6 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
             or the group that contributes 3/4 of the time in this timeframe (excluding star and fork contributions).
         """
         date_list = [x for x in list(pd.date_range(freq='W-MON', start=from_date, end=date))]
-        if len(date_list) >= 4:
-            weeks = len(date_list) * 3 / 4
         contribution_count_dict = {k: v["contribution_without_observe"] for k, v in contributor_dict.items()}
         sorted_dict = {k: v for k, v in
                        sorted(contribution_count_dict.items(), key=lambda item: item[1], reverse=True)}
@@ -524,9 +522,11 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
             result_contributor[k] = {**contributor_dict[k], "mileage_type": "regular"}
             if current_sum >= target_sum:
                 break
-        for k, v in contributor_dict.items():
-            if v["contribution_weeks"] >= weeks:
-                result_contributor[k] = {**v, "mileage_type": "regular"}
+        if len(date_list) >= 4:
+            weeks = len(date_list) * 3 / 4
+            for k, v in contributor_dict.items():
+                if v["contribution_weeks"] >= weeks:
+                    result_contributor[k] = {**v, "mileage_type": "regular"}
         core_name = core_contributor.keys()
         return {k: result_contributor[k] for k in result_contributor.keys() if k not in core_name}
 

--- a/tests/test_contributor_detail_list.py
+++ b/tests/test_contributor_detail_list.py
@@ -1,0 +1,54 @@
+import datetime
+import unittest
+from unittest.mock import patch
+
+from compass_metrics import contributor_metrics
+from compass_metrics_v2 import contributor_metrics_v2
+
+
+def _make_source(contributor, contribution=10):
+    return {
+        "contributor": contributor,
+        "contribution": contribution,
+        "contribution_without_observe": contribution,
+        "ecological_type": "individual participant",
+        "organization": "example-org",
+        "is_bot": False,
+        "repo_name": "demo/repo",
+        "contribution_type_list": [{"contribution_type": "code", "contribution": contribution}],
+    }
+
+
+class ContributorDetailListShortWindowTest(unittest.TestCase):
+    """issue #195: 少于四周的分析窗口不应抛 UnboundLocalError。"""
+
+    def _run(self, module):
+        date = datetime.datetime(2026, 9, 1)
+        from_date = date - datetime.timedelta(days=3)
+        source_list = [_make_source("alice")]
+        with patch.object(module, "get_contributor_list", return_value=source_list):
+            return module.contributor_detail_list(
+                client=None,
+                contributors_enriched_index="test-index",
+                date=date,
+                repo_list=["demo/repo"],
+                from_date=from_date,
+            )
+
+    def test_short_window_v2(self):
+        result = self._run(contributor_metrics_v2)
+        self.assertEqual(result["core_count"], 1)
+        self.assertEqual(result["regular_count"], 0)
+        self.assertEqual(result["casual_count"], 0)
+        self.assertEqual(len(result["contributor_detail_list"]), 1)
+
+    def test_short_window_v1(self):
+        result = self._run(contributor_metrics)
+        self.assertEqual(result["core_count"], 1)
+        self.assertEqual(result["regular_count"], 0)
+        self.assertEqual(result["casual_count"], 0)
+        self.assertEqual(len(result["contributor_detail_list"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix `UnboundLocalError` in `contributor_detail_list` when the analysis window is shorter than four weeks.

## Problem

`get_regular_contributor` referenced the local variable `weeks`, but `weeks` is only assigned when `len(date_list) >= 4`:

```python
date_list = [x for x in pd.date_range(freq='W-MON', start=from_date, end=date)]
if len(date_list) >= 4:
    weeks = len(date_list) * 3 / 4
...
for k, v in contributor_dict.items():
    if v["contribution_weeks"] >= weeks:  # UnboundLocalError when window < 4 weeks
```

For a one-day / few-day analysis window, `weeks` is never assigned and the function crashes instead of returning the contributor breakdown.

## Fix

Guard the "contributed 3/4 of the time" additional rule with the same length check, so short windows fall back to the contribution-based `regular` threshold:

```python
if len(date_list) >= 4:
    weeks = len(date_list) * 3 / 4
    for k, v in contributor_dict.items():
        if v["contribution_weeks"] >= weeks:
            result_contributor[k] = {**v, "mileage_type": "regular"}
```

Applied to both the v1 (`compass_metrics`) and v2 (`compass_metrics_v2`) copies of the function.

## Test plan

Added `tests/test_contributor_detail_list.py` with a short-window (3-day) regression test for both versions, using `unittest` + `unittest.mock` to stub `get_contributor_list`.

```
python -m unittest tests.test_contributor_detail_list -v
```

Fixes #195
