### PR TITLE
fix: exclude openharmony_ci bot by exact name instead of substring

### DIFF
--- a/compass_metrics/contributor_metrics.py
+++ b/compass_metrics/contributor_metrics.py
@@ -546,7 +546,7 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
             "contribution_weeks": len(list(group))
         }
         if is_bot is contributor_item["is_bot"]:
-            if key not in "openharmony_ci":
+            if key != "openharmony_ci":
                 contributor_dict[key] = contributor_item
 
     core_contributor = get_core_contributor(contributor_dict)

--- a/compass_metrics_v2/contributor_metrics_v2.py
+++ b/compass_metrics_v2/contributor_metrics_v2.py
@@ -589,7 +589,7 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
             "contribution_weeks": len(list(group))
         }
         if is_bot is contributor_item["is_bot"]:
-            if key not in "openharmony_ci":
+            if key != "openharmony_ci":
                 contributor_dict[key] = contributor_item
 
     core_contributor = get_core_contributor(contributor_dict)

--- a/tests/test_openharmony_ci_exclusion.py
+++ b/tests/test_openharmony_ci_exclusion.py
@@ -1,0 +1,61 @@
+import datetime
+import unittest
+from unittest.mock import patch
+
+from compass_metrics import contributor_metrics
+from compass_metrics_v2 import contributor_metrics_v2
+
+
+def _make_source(contributor, contribution=10):
+    return {
+        "contributor": contributor,
+        "contribution": contribution,
+        "contribution_without_observe": contribution,
+        "ecological_type": "individual participant",
+        "organization": "example-org",
+        "is_bot": False,
+        "repo_name": "demo/repo",
+        "contribution_type_list": [{"contribution_type": "code", "contribution": contribution}],
+    }
+
+
+class OpenharmonyCiExclusionTest(unittest.TestCase):
+    """CI bot 排除用精确匹配，不再把 openharmony_ci 的子串误当作 bot 排除。"""
+
+    def _run(self, module, names):
+        date = datetime.datetime(2026, 9, 1)
+        from_date = date - datetime.timedelta(days=90)
+        source_list = [_make_source(n) for n in names]
+        with patch.object(module, "get_contributor_list", return_value=source_list):
+            return module.contributor_detail_list(
+                client=None,
+                contributors_enriched_index="test-index",
+                date=date,
+                repo_list=["demo/repo"],
+                from_date=from_date,
+            )
+
+    def test_substring_contributor_not_excluded_v2(self):
+        # "openharmony" 是 "openharmony_ci" 的子串，不应被当作 bot 排除
+        result = self._run(contributor_metrics_v2, ["openharmony"])
+        self.assertEqual(result["core_count"], 1)
+
+    def test_substring_contributor_not_excluded_v1(self):
+        result = self._run(contributor_metrics, ["openharmony"])
+        self.assertEqual(result["core_count"], 1)
+
+    def test_exact_ci_bot_excluded_v2(self):
+        result = self._run(contributor_metrics_v2, ["openharmony_ci"])
+        self.assertEqual(result["core_count"], 0)
+        self.assertEqual(result["regular_count"], 0)
+        self.assertEqual(result["casual_count"], 0)
+
+    def test_exact_ci_bot_excluded_v1(self):
+        result = self._run(contributor_metrics, ["openharmony_ci"])
+        self.assertEqual(result["core_count"], 0)
+        self.assertEqual(result["regular_count"], 0)
+        self.assertEqual(result["casual_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the CI-bot exclusion in `contributor_detail_list` using a substring test instead of an exact match.

## Problem

```python
if key not in "openharmony_ci":   # substring test
    contributor_dict[key] = contributor_item
```

`x not in "openharmony_ci"` is a substring check, so any contributor whose login is a substring of `"openharmony_ci"` (e.g. `openharmony`, `harmony`, `ci`, `open`) was silently dropped from the result. The intent is to exclude only the `openharmony_ci` bot account.

## Fix

Compare by value with `!=` so only the exact `openharmony_ci` login is excluded. Applied to both v1 (`compass_metrics`) and v2 (`compass_metrics_v2`).

## Test plan

Added `tests/test_openharmony_ci_exclusion.py`:
- a contributor named `openharmony` (substring) is kept;
- a contributor named `openharmony_ci` (exact) is still excluded.

```
python -m unittest tests.test_openharmony_ci_exclusion -v
```