### PR TITLE
fix: align quarterly windows in activity_quarterly_contribution with calendar quarters

### DIFF
--- a/compass_metrics/activity.py
+++ b/compass_metrics/activity.py
@@ -42,26 +42,19 @@ def activity_quarterly_contribution(client, contributors_index: str, repo_list: 
     result_bot = []
     result_without_bot = []
 
-    # 获取当前季度的结束时间（将日期调整到季度末）
-    current_quarter_end = date.replace(
-        month=((date.month - 1) // 3 * 3 + 3),
+    # 获取当前季度的起始时间（将日期调整到季度初）。以季度首日为锚点做
+    # 月份加减，避免从月末日期回推时因每月天数不同产生错位
+    # （如 6月30日减3个月得到3月30日而非3月31日）
+    current_quarter_start = date.replace(
+        month=((date.month - 1) // 3 * 3 + 1),
         day=1
     )
-    # 调整到月末
-    if current_quarter_end.month == 3:
-        current_quarter_end = current_quarter_end.replace(day=31)
-    elif current_quarter_end.month == 6:
-        current_quarter_end = current_quarter_end.replace(day=30)
-    elif current_quarter_end.month == 9:
-        current_quarter_end = current_quarter_end.replace(day=30)
-    elif current_quarter_end.month == 12:
-        current_quarter_end = current_quarter_end.replace(day=31)
 
     # 计算最近4个季度的贡献量
     for i in range(4):
         # 计算季度的起止时间
-        quarter_end = current_quarter_end - relativedelta(months=3 * i)
-        quarter_start = quarter_end - relativedelta(months=3) + timedelta(days=1)
+        quarter_start = current_quarter_start - relativedelta(months=3 * i)
+        quarter_end = quarter_start + relativedelta(months=3) - timedelta(days=1)
 
         quarter_data = commit_count(
             client,

--- a/tests/test_activity_quarterly_contribution.py
+++ b/tests/test_activity_quarterly_contribution.py
@@ -1,0 +1,70 @@
+"""Regression tests for the activity_quarterly_contribution metric.
+
+These tests patch the network call (GitHub release lookup) and the
+contributor search so no Elasticsearch instance or network access is
+required, and check that the four quarterly windows are the natural
+calendar quarters: each calendar day is counted in exactly one quarter.
+"""
+import compass_metrics.activity as activity
+import compass_metrics.git_metrics as git_metrics
+
+NON_BOT_CONTRIBUTOR = {
+    "is_bot": False,
+    "code_author_date_list": ["2025-12-31", "2026-03-31", "2026-04-01"],
+}
+BOT_CONTRIBUTOR = {
+    "is_bot": True,
+    "code_author_date_list": ["2026-07-01"],
+}
+
+
+def test_quarter_windows_are_natural_calendar_quarters(monkeypatch):
+    monkeypatch.setattr(
+        activity, "get_github_versionPublishAt",
+        lambda *args, **kwargs: "2026-09-05T00:00:00Z")
+    monkeypatch.setattr(
+        git_metrics, "get_contributor_list",
+        lambda *args, **kwargs: [dict(NON_BOT_CONTRIBUTOR), dict(BOT_CONTRIBUTOR)])
+
+    result = activity.activity_quarterly_contribution(
+        None, "contributors_index", ["https://github.com/o/r"], "v1.0")
+
+    # The four windows must be Q3'26, Q2'26, Q1'26, Q4'25 as natural
+    # calendar quarters: [Jul 1-Sep 30], [Apr 1-Jun 30], [Jan 1-Mar 31],
+    # [Oct 1-Dec 31]. Every commit day belongs to exactly one window.
+    assert result["activity_quarterly_contribution"] == [1, 1, 1, 1]
+    assert result["activity_quarterly_contribution_bot"] == [1, 0, 0, 0]
+    assert result["activity_quarterly_contribution_without_bot"] == [0, 1, 1, 1]
+    assert result["activity_quarterly_contribution_info"] == "success"
+
+
+def test_quarter_windows_align_when_publish_date_is_quarter_start(monkeypatch):
+    monkeypatch.setattr(
+        activity, "get_github_versionPublishAt",
+        lambda *args, **kwargs: "2026-10-01T00:00:00Z")
+    quarter_start_day_contributor = {
+        "is_bot": False,
+        "code_author_date_list": ["2025-12-31", "2026-03-31", "2026-04-01", "2026-10-01"],
+    }
+    monkeypatch.setattr(
+        git_metrics, "get_contributor_list",
+        lambda *args, **kwargs: [quarter_start_day_contributor])
+
+    result = activity.activity_quarterly_contribution(
+        None, "contributors_index", ["https://github.com/o/r"], "v1.0")
+
+    # Publish date in Q4'26: windows are Q4'26, Q3'26, Q2'26, Q1'26. The
+    # publish day itself belongs to Q4'26, Mar 31 to Q1'26, Apr 1 to Q2'26,
+    # and Dec 31 2025 falls outside the four windows.
+    assert result["activity_quarterly_contribution"] == [1, 0, 1, 1]
+
+
+def test_returns_failure_info_when_release_not_found(monkeypatch):
+    monkeypatch.setattr(
+        activity, "get_github_versionPublishAt", lambda *args, **kwargs: None)
+
+    result = activity.activity_quarterly_contribution(
+        None, "contributors_index", ["https://github.com/o/r"], "v9.9.9")
+
+    assert result["activity_quarterly_contribution"] == []
+    assert "Failed" in result["activity_quarterly_contribution_info"]


### PR DESCRIPTION
## Problem

`activity_quarterly_contribution` derives the four quarterly windows by snapping the release date to the current quarter's **end** date, then computing each earlier window as `quarter_end - 3 months` (end) and `quarter_end - 3 months + 1 day` (start).

Subtracting `relativedelta(months=3)` from a month-end date does **not** land on the previous quarter's end date, because adjacent quarter-end days differ (Mar 31 vs Jun 30 vs Sep 30 vs Dec 31). For a release date in Q3 (anchor = Sep 30):

| i | computed window | natural quarter | problem |
|---|-----------------|-----------------|---------|
| 1 | [Mar 31, Jun 30] | [Apr 1, Jun 30] | Mar 31 (a Q1 day) is counted in the Q2 window |
| 2 | [Dec 31, Mar 30] | [Jan 1, Mar 31] | Dec 31 (a Q4 day) is counted here; Mar 31 is missed |
| 3 | [Oct 1, Dec 30] | [Oct 1, Dec 31] | Dec 31 is missed |

`get_commit_count` uses inclusive bounds (`from_date_str <= commit_date <= to_date_str`), so a commit on a boundary day is counted in **two** adjacent quarters, and some days fall out of their own quarter entirely. This misalignment affects 3 of the 4 windows for Q1/Q3 anchors (day-31 vs day-30 mismatch on both sides).

## Fix

Anchor on the current quarter's **start** (day=1) and derive each window forward from it:

```python
current_quarter_start = date.replace(month=((date.month - 1) // 3 * 3 + 1), day=1)
for i in range(4):
    quarter_start = current_quarter_start - relativedelta(months=3 * i)
    quarter_end = quarter_start + relativedelta(months=3) - timedelta(days=1)
```

Day-1 anchors are stable under month arithmetic, so each window is exactly the natural calendar quarter — windows neither overlap nor skip days. The month-end if/elif chain becomes unnecessary and is removed.

## Verification

Environment: Docker `python:3.9` image, dependencies from `requirements.txt` (with numpy<2 for elasticsearch 6.x compatibility), tests run via `python -m pytest`. The new tests patch the GitHub release lookup and the contributor search, so no network or Elasticsearch instance is needed.

**Before the fix** (base 3b5b042) — 2 failures showing boundary days double-counted / misplaced:

```
E       assert [1, 2, 1, 0] == [1, 1, 1, 1]
E         At index 1 diff: 2 != 1
FAILED tests/test_activity_quarterly_contribution.py::test_quarter_windows_are_natural_calendar_quarters
E       assert [1, 0, 2, 1] == [1, 0, 1, 1]
E         At index 2 diff: 2 != 1
FAILED tests/test_activity_quarterly_contribution.py::test_quarter_windows_align_when_publish_date_is_quarter_start
2 failed, 1 passed in 0.24s   (the 1 pass is the release-not-found regression guard)
```

**After the fix**:

```
tests/test_activity_quarterly_contribution.py::test_quarter_windows_are_natural_calendar_quarters PASSED
tests/test_activity_quarterly_contribution.py::test_quarter_windows_align_when_publish_date_is_quarter_start PASSED
tests/test_activity_quarterly_contribution.py::test_returns_failure_info_when_release_not_found PASSED
3 passed in 0.23s
```

`flake8 --ignore=E501` reports no new violations on the changed lines (only pre-existing ones elsewhere in `activity.py`).

## AI disclosure

This contribution was prepared with the assistance of an AI coding agent (GLM, operated by the account owner). The bug analysis, fix, and tests were reviewed by the account owner; all test evidence above was actually executed in the environment described.
