### PR TITLE
fix: contribution_weeks was always 0 (groupby group consumed before counting)

### DIFF
--- a/compass_metrics/contributor_metrics.py
+++ b/compass_metrics/contributor_metrics.py
@@ -515,7 +515,10 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
         contribution_type_dict = {}
         is_bot_set = set()
         repo_name_set = set()
-        for item in list(group):
+        # materialize the group once: a groupby iterator is exhausted after
+        # the first pass, so counting it again afterwards would always yield 0
+        group_list = list(group)
+        for item in group_list:
             contribution += item["contribution"]
             contribution_without_observe += item["contribution_without_observe"]
             ecological_type_set.add(item["ecological_type"])
@@ -543,7 +546,7 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
             "contribution_type_list": list(contribution_type_dict.values()),
             "is_bot": True if True in is_bot_set else False,
             "repo_name": list(repo_name_set),
-            "contribution_weeks": len(list(group))
+            "contribution_weeks": len(group_list)
         }
         if is_bot is contributor_item["is_bot"]:
             if key not in "openharmony_ci":

--- a/compass_metrics_v2/contributor_metrics_v2.py
+++ b/compass_metrics_v2/contributor_metrics_v2.py
@@ -558,7 +558,10 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
         contribution_type_dict = {}
         is_bot_set = set()
         repo_name_set = set()
-        for item in list(group):
+        # materialize the group once: a groupby iterator is exhausted after
+        # the first pass, so counting it again afterwards would always yield 0
+        group_list = list(group)
+        for item in group_list:
             contribution += item["contribution"]
             contribution_without_observe += item["contribution_without_observe"]
             ecological_type_set.add(item["ecological_type"])
@@ -586,7 +589,7 @@ def contributor_detail_list(client, contributors_enriched_index, date, repo_list
             "contribution_type_list": list(contribution_type_dict.values()),
             "is_bot": True if True in is_bot_set else False,
             "repo_name": list(repo_name_set),
-            "contribution_weeks": len(list(group))
+            "contribution_weeks": len(group_list)
         }
         if is_bot is contributor_item["is_bot"]:
             if key not in "openharmony_ci":

--- a/tests/test_contributor_detail_list_weeks.py
+++ b/tests/test_contributor_detail_list_weeks.py
@@ -1,0 +1,79 @@
+"""Regression tests for the weekly activity counting in contributor_detail_list.
+
+The enriched index holds one document per (contributor, repo, week), and
+contributor_detail_list records the number of weekly documents per contributor
+in contribution_weeks. get_regular_contributor promotes contributors who were
+active in at least 3/4 of the weeks to "regular" even when they are outside
+the cumulative 80% contribution group.
+
+These tests patch the Elasticsearch access so no instance or network access
+is required.
+"""
+import datetime
+
+import pytest
+
+import compass_metrics.contributor_metrics as contributor_metrics_v1
+import compass_metrics_v2.contributor_metrics_v2 as contributor_metrics_v2
+
+FROM_DATE = datetime.date(2026, 1, 5)   # a Monday
+TO_DATE = datetime.date(2026, 4, 6)     # 14 Mondays later
+
+
+def weekly_doc(contributor, contribution, repo="https://github.com/o/r"):
+    return {
+        "contributor": contributor,
+        "contribution": contribution,
+        "contribution_without_observe": contribution,
+        "ecological_type": "individual participant",
+        "organization": None,
+        "contribution_type_list": [
+            {"contribution_type": "code_author", "contribution": contribution}
+        ],
+        "is_bot": False,
+        "repo_name": repo,
+    }
+
+
+def fake_docs():
+    # "steady" is active in 11 of the 14 weeks with 1 contribution each;
+    # "bursty" has a single weekly doc with 100 contributions.
+    steady = [weekly_doc("steady", 1) for _ in range(11)]
+    bursty = [weekly_doc("bursty", 100)]
+    return [{"_source": doc} for doc in steady + bursty]
+
+
+@pytest.mark.parametrize("module", [contributor_metrics_v1, contributor_metrics_v2])
+def test_contribution_weeks_counts_weekly_docs(module, monkeypatch):
+    monkeypatch.setattr(
+        module, "get_all_index_data",
+        lambda *args, **kwargs: fake_docs())
+
+    detail = module.contributor_detail_list(
+        None, "contributors_enriched_index", TO_DATE, ["https://github.com/o/r"],
+        from_date=FROM_DATE)
+
+    steady = next(item for item in detail["contributor_detail_list"]
+                  if item["contributor"] == "steady")
+    assert steady["contribution_weeks"] == 11
+
+
+@pytest.mark.parametrize("module", [contributor_metrics_v1, contributor_metrics_v2])
+def test_three_quarters_active_contributor_is_regular(module, monkeypatch):
+    monkeypatch.setattr(
+        module, "get_all_index_data",
+        lambda *args, **kwargs: fake_docs())
+
+    detail = module.contributor_detail_list(
+        None, "contributors_enriched_index", TO_DATE, ["https://github.com/o/r"],
+        from_date=FROM_DATE)
+
+    # "bursty" alone reaches the 50% core threshold; "steady", active in
+    # 11 >= 14 * 3/4 weeks, must be classified as regular, not casual.
+    assert detail["core_count"] == 1
+    assert detail["regular_count"] == 1
+    assert detail["casual_count"] == 0
+
+    steady = next(item for item in detail["contributor_detail_list"]
+                  if item["contributor"] == "steady")
+    assert steady["mileage_type"] == "regular"


### PR DESCRIPTION
## Problem

`contributor_detail_list` builds each contributor's entry with:

```python
for item in list(group):     # aggregates the contributor's docs
    ...
"contribution_weeks": len(list(group))   # always 0
```

A `groupby` group is an iterator: `list(group)` in the aggregation loop exhausts it, so the second `list(group)` always returns `[]` and `contribution_weeks` is **0 for every contributor** — in both `compass_metrics/contributor_metrics.py` and its v2 copy `compass_metrics_v2/contributor_metrics_v2.py` (same code added in "add v2 model").

The enriched index holds one document per `(contributor, repo, week)` (written by `contributor_enrich` with `get_uuid(contributor, repo, str(date))` on weekly dates), so `len(list(group))` is the contributor's number of active weekly documents — the value `contribution_weeks` is meant to carry.

Because of the bug, the 3/4-of-weeks promotion in `get_regular_contributor`:

```python
if v["contribution_weeks"] >= weeks:   # 0 >= weeks never true
```

never fires. Contributors active in ≥ 3/4 of the weeks but outside the cumulative-80% group are all classified `casual` instead of `regular`, which skews `activity_regular_contributor_count`, `activity_casual_contributor_count`, `regular_count`/`casual_count`, and the regular/casual per-person metrics registered in `compass_model/base_metrics_model.py` / `base_metrics_model_v2.py`.

## Fix

Materialize the group once (`group_list = list(group)`) and count that list for `contribution_weeks`, in both the v1 and v2 copies.

## Verification

New test `tests/test_contributor_detail_list_weeks.py` (patches the Elasticsearch access; scenario: `steady` active in 11 of 14 weekly documents with 1 contribution each, `bursty` with a single 100-contribution document):

- before the fix: all 4 tests fail — `contribution_weeks` is 0 and `steady` is classified `casual` (`regular_count` 0, `casual_count` 1);
- after the fix: 4 passed — `contribution_weeks` is 11, `steady` is `regular` (`core_count` 1, `regular_count` 1, `casual_count` 0).

**AI disclosure:** This change was prepared with AI assistance (GitHub Copilot/Claude-style tooling guided by a human contributor).
