### PR TITLE
fix: LOC_frequency_year divides 3-year sum by the 90-day divisor (12.85)

### DIFF
--- a/compass_metrics/git_metrics.py
+++ b/compass_metrics/git_metrics.py
@@ -447,4 +447,4 @@ def LOC_frequency_year(client, git_index, date, repos_list, field='lines_changed
         from_date=(date - relativedelta(years=3)).replace(month=1, day=1), to_date=date)
     loc_frequency = client.search(index=git_index, body=query_LOC_frequency)[
         'aggregations']['count_of_uuid']['value']
-    return loc_frequency / 12.85
+    return loc_frequency / 156.43

--- a/compass_metrics_v2/git_metrics_v2.py
+++ b/compass_metrics_v2/git_metrics_v2.py
@@ -444,7 +444,7 @@ def LOC_frequency_year(client, git_index, date, repos_list, field='lines_changed
         from_date=(date - relativedelta(years=3)).replace(month=1, day=1), to_date=date)
     loc_frequency = client.search(index=git_index, body=query_LOC_frequency)[
         'aggregations']['count_of_uuid']['value']
-    return loc_frequency / 12.85
+    return loc_frequency / 156.43
 
 
 # =========================

--- a/tests/test_loc_frequency_year.py
+++ b/tests/test_loc_frequency_year.py
@@ -1,0 +1,52 @@
+"""Regression tests for the weekly divisor of LOC_frequency_year.
+
+LOC_frequency_year sums ``lines_changed`` over the past 3 years (from Jan 1 of
+the calendar year 3 years back up to ``date``) and reports the average number
+of lines touched per week. The 90-day sibling LOC_frequency divides its sum by
+12.85 (90/7 weeks); the 3-year window must instead be divided by 156.43
+(3*365/7 weeks), the same fixed-divisor convention used by
+commit_frequency_last_year (52.14 = 365/7 for a 1-year window).
+
+These tests patch the Elasticsearch access so no instance or network access
+is required.
+"""
+import datetime
+
+import pytest
+
+import compass_metrics.git_metrics as git_metrics_v1
+import compass_metrics_v2.git_metrics_v2 as git_metrics_v2
+
+DATE = datetime.date(2026, 9, 6)
+WEEKS_IN_3_YEARS = 3 * 365 / 7  # 156.4285... -> codebase uses 156.43
+REPOS = ["https://github.com/oss-compass/compass-metrics-model"]
+TOTAL_LINES = 1564.3  # so the true weekly average is 10.0
+
+
+class FakeSearchClient:
+    def __init__(self, value):
+        self.value = value
+        self.queries = []
+
+    def search(self, index=None, body=None):
+        self.queries.append(body)
+        return {"aggregations": {"count_of_uuid": {"value": self.value}}}
+
+
+@pytest.mark.parametrize("module", [git_metrics_v1, git_metrics_v2])
+def test_loc_frequency_year_divides_by_weeks_in_3_years(module):
+    client = FakeSearchClient(TOTAL_LINES)
+    result = module.LOC_frequency_year(client, "git", DATE, REPOS)
+    assert result == pytest.approx(TOTAL_LINES / 156.43)
+
+
+@pytest.mark.parametrize("module", [git_metrics_v1, git_metrics_v2])
+def test_loc_frequency_year_queries_a_3_year_window(module):
+    client = FakeSearchClient(TOTAL_LINES)
+    module.LOC_frequency_year(client, "git", DATE, REPOS)
+    date_range = client.queries[0]["query"]["bool"]["filter"][0]["range"][
+        "grimoire_creation_date"
+    ]
+    # The window starts on Jan 1 of the calendar year 3 years back.
+    assert date_range["gte"] == "2023-01-01"
+    assert date_range["lt"] == "2026-09-06"


### PR DESCRIPTION
## Motivation

`LOC_frequency_year` ([compass_metrics/git_metrics.py:442](https://github.com/oss-compass/compass-metrics-model/blob/main/compass_metrics/git_metrics.py#L442)) is documented as *"the average number of lines touched per week in the past 3 years"*, and its OpenSearch query really does sum `lines_changed` over a ~3-year window (from Jan 1 of the calendar year 3 years back up to `date`).

But the final line divides the sum by **12.85**:

```python
return loc_frequency / 12.85
```

12.85 = 90/7 is the weeks-per-90-days divisor that belongs to the sibling `LOC_frequency` (a 90-day window, line 406). Dividing a 3-year total by 12.85 inflates the reported weekly average by roughly **12.2×** (3*365/7 / 12.85 ≈ 12.17).

The codebase's fixed-divisor convention is:
* 90-day window → /12.85 (weeks in 90 days)
* 1-year window → /52.14 (`commit_frequency_last_year`, line 83)
* 3-year window → **/156.43** (3*365/7) ← this PR

The metric is registered as `lines_of_code_frequency_year` in `compass_model/base_metrics_model.py` (line 632) and `base_metrics_model_v2.py` (line 751), so the inflated value flows straight into the metric output. The same duplicated function in `compass_metrics_v2/git_metrics_v2.py` (line 447) is fixed as well.

## Change

```diff
-    return loc_frequency / 12.85
+    return loc_frequency / 156.43
```

in both `compass_metrics/git_metrics.py` and `compass_metrics_v2/git_metrics_v2.py`.

## Verification

Added `tests/test_loc_frequency_year.py` (no ES instance needed; the search client is faked):

1. **Window check**: `LOC_frequency_year` queries `grimoire_creation_date` from `2023-01-01` (Jan 1 of the calendar year 3 years before 2026-09-06) to `2026-09-06` — confirming the window really spans 3 years, which is what motivates the 156.43 divisor.
2. **Divisor check**: with a fake sum of 1564.3, the result must be `1564.3 / 156.43 = 10.0`.

Fail-before / pass-after (both v1 and v2 implementations are parametrized):

```
$ python -m pytest tests/test_loc_frequency_year.py -q
# before fix
FAILED tests/test_loc_frequency_year.py::test_loc_frequency_year_divides_by_weeks_in_3_years[compass_metrics.git_metrics]
FAILED tests/test_loc_frequency_year.py::test_loc_frequency_year_divides_by_weeks_in_3_years[compass_metrics_v2.git_metrics_v2]
2 failed, 2 passed

# after fix
4 passed
```

Full suite regression:

```
$ python -m pytest tests/ -q
4 passed
```

flake8 (repo config `ignore = E501`): no new warnings introduced by the changed lines; the new test file is clean.

Signed-off-by: zjncs <18910855655@163.com>