### PR TITLE
fix: time_to_close raises ZeroDivisionError when no issue carries state

### DIFF
--- a/compass_metrics/issue_metrics.py
+++ b/compass_metrics/issue_metrics.py
@@ -281,6 +281,8 @@ def time_to_close(client, issue_index, date, repos_list, from_date=None):
                 close_time_repo.append(get_time_diff_days(item['_source']['created_at'], item['_source']['closed_at']))
             else:
                 close_time_repo.append(get_time_diff_days(item['_source']['created_at'], date_str))
+    if len(close_time_repo) == 0:
+        return {"time_to_close_avg": None, "time_to_close_mid": None}
     close_time_avg = sum(close_time_repo) / len(close_time_repo)
     close_time_mid = get_medium(close_time_repo)
     result = {

--- a/tests/test_time_to_close_empty.py
+++ b/tests/test_time_to_close_empty.py
@@ -1,0 +1,53 @@
+"""Regression tests for time_to_close with documents lacking the state field.
+
+time_to_close collects per-issue durations only from documents whose _source
+contains the 'state' field. When the fetched page is non-empty but every
+document is missing 'state' (or has no usable timestamp), the collection
+stays empty and the function used to divide sum([]) by len([]), raising
+ZeroDivisionError. The sibling metric bug_issue_open_time guards this case
+and returns None; time_to_close must do the same.
+
+These tests patch the OpenSearch access so no instance or network access is
+required.
+"""
+import datetime
+
+import pytest
+
+from compass_metrics.issue_metrics import time_to_close
+
+DATE = datetime.date(2026, 9, 6)
+REPOS = ["https://github.com/oss-compass/compass-metrics-model"]
+
+
+def closed_issue(created_at, closed_at, state="closed"):
+    return {"_source": {"created_at": created_at, "closed_at": closed_at, "state": state}}
+
+
+def test_time_to_close_returns_none_when_no_issue_has_state(monkeypatch):
+    # Non-empty page, but no document carries the 'state' field.
+    items = [{"_source": {"created_at": "2026-06-01", "closed_at": "2026-06-11"}}]
+    monkeypatch.setattr("compass_metrics.issue_metrics.get_all_index_data",
+                        lambda client, index, body: items)
+    result = time_to_close(None, "issue", DATE, REPOS)
+    assert result == {"time_to_close_avg": None, "time_to_close_mid": None}
+
+
+def test_time_to_close_averages_closed_and_open_issues(monkeypatch):
+    # 10 days for the closed issue, 92 days (up to DATE) for the open one.
+    items = [
+        closed_issue("2026-06-01", "2026-06-11"),
+        closed_issue("2026-06-06", None, state="open"),
+    ]
+    monkeypatch.setattr("compass_metrics.issue_metrics.get_all_index_data",
+                        lambda client, index, body: items)
+    result = time_to_close(None, "issue", DATE, REPOS)
+    assert result["time_to_close_avg"] == pytest.approx(51.0)
+    assert result["time_to_close_mid"] == pytest.approx(51.0)
+
+
+def test_time_to_close_returns_none_when_page_is_empty(monkeypatch):
+    monkeypatch.setattr("compass_metrics.issue_metrics.get_all_index_data",
+                        lambda client, index, body: [])
+    result = time_to_close(None, "issue", DATE, REPOS)
+    assert result == {"time_to_close_avg": None, "time_to_close_mid": None}


### PR DESCRIPTION
## Motivation

`time_to_close` ([compass_metrics/issue_metrics.py:260](https://github.com/oss-compass/compass-metrics-model/blob/main/compass_metrics/issue_metrics.py#L260)) collects per-issue durations **only** from documents whose `_source` contains the `state` field:

```python
for item in close_time_items:
    if 'state' in item['_source']:
        ...
close_time_avg = sum(close_time_repo) / len(close_time_repo)   # line 284
```

When the fetched page is non-empty but **every** document is missing `state`, `close_time_repo` stays empty and the function divides `sum([])` by `len([])`, crashing the whole metrics model run with `ZeroDivisionError` instead of reporting no data.

The sibling metric `bug_issue_open_time` (line 75-77) already guards exactly this case:

```python
issue_open_time_repo = list(filter(lambda x: x >= 0, issue_open_time_repo))
if len(issue_open_time_repo) == 0:
    return { "bug_issue_open_time_avg": None, "bug_issue_open_time_mid": None }
```

and the empty-page branch of `time_to_close` itself returns `None` values. The metric is registered as `time_to_close` in `compass_model/base_metrics_model.py` (line 639), so one such index page aborts the model run rather than degrading gracefully.

## Change

Mirror the sibling's guard after the collection loop:

```diff
             else:
                 close_time_repo.append(get_time_diff_days(item['_source']['created_at'], date_str))
+    if len(close_time_repo) == 0:
+        return {"time_to_close_avg": None, "time_to_close_mid": None}
     close_time_avg = sum(close_time_repo) / len(close_time_repo)
```

## Verification

Added `tests/test_time_to_close.py` (OpenSearch access patched; no instance or network needed):

1. **The bug**: a non-empty page whose documents lack `state` → previously `ZeroDivisionError` at issue_metrics.py:284, now `{"time_to_close_avg": None, "time_to_close_mid": None}`.
2. **Control (semantics locked)**: one closed issue (10 days) + one open issue (92 days up to the analysis date) → avg/mid = 51.
3. **Control**: empty page → `None`/`None` (unchanged behavior).

Fail-before / pass-after:

```
$ python -m pytest tests/test_time_to_close_empty.py -q
# before fix
FAILED ...::test_time_to_close_returns_none_when_no_issue_has_state  # ZeroDivisionError at issue_metrics.py:284
1 failed, 2 passed

# after fix
3 passed
```

flake8 (repo config `ignore = E501`): the new test file is clean; no new warnings on changed lines.

Signed-off-by: zjncs <18910855655@163.com>