### PR TITLE
fix: is_modular never counts functions for java/php/go/perl

### DIFF
--- a/compass_metrics/code_readability.py
+++ b/compass_metrics/code_readability.py
@@ -96,19 +96,22 @@ def is_modular(file_path):
         class_count = 0
         language = detect_language(file_path)
         
-        if language in ['python', 'ruby', 'perl', 'shell', 'r']:
+        if language in ['python', 'ruby', 'shell', 'r']:
             function_syntax = 'def '
             class_syntax = 'class '
-        elif language in ['java', 'javascript', 'php', 'go']:
-            function_syntax = 'function' if language == 'javascript' else 'def '
+        elif language == 'perl':
+            function_syntax = 'sub '
+            class_syntax = 'package '
+        elif language in ['javascript', 'php', 'go']:
+            function_syntax = {'javascript': 'function', 'php': 'function ', 'go': 'func '}[language]
             class_syntax = 'class '
-        elif language in ['c', 'cpp']:
+        elif language in ['java', 'c', 'cpp']:
             function_syntax = re.compile(r'\w+\s+\w+\s*\([^)]*\)\s*{')
             class_syntax = 'class '
-        
+
         for line in lines:
             stripped_line = line.strip()
-            if language in ['c', 'cpp']:
+            if language in ['java', 'c', 'cpp']:
                 if function_syntax.search(stripped_line):
                     function_count += 1
                 if class_syntax in stripped_line:

--- a/tests/test_is_modular.py
+++ b/tests/test_is_modular.py
@@ -1,0 +1,97 @@
+"""Regression tests for is_modular language-specific keywords.
+
+is_modular counted function/class declarations by checking whether a line
+starts with a keyword. Java, PHP and Go were given Python's 'def ' keyword
+(which never appears in those languages) and perl uses 'sub', so
+function_count was always 0 for them; Java class declarations carry access
+modifiers before 'class' ('public class Foo') and never matched
+startswith('class ') either.
+
+These tests run on temporary files, so no repository checkout or network
+access is required.
+"""
+import textwrap
+
+from compass_metrics.code_readability import is_modular
+
+JAVA = """
+public class Foo {
+    public void bar() {
+    }
+}
+"""
+
+PHP = """
+<?php
+function add($a, $b) {
+    return $a + $b;
+}
+class Calculator {
+}
+"""
+
+GO = """
+package main
+
+func main() {
+}
+"""
+
+PERL = """
+sub compute {
+    return 1;
+}
+package Utils;
+"""
+
+PYTHON = """
+def foo():
+    pass
+
+class Bar:
+    pass
+"""
+
+JAVASCRIPT = """
+function foo() {
+}
+
+class Bar {
+}
+"""
+
+
+def test_java_counts_methods_and_class(tmp_path):
+    path = tmp_path / "Foo.java"
+    path.write_text(textwrap.dedent(JAVA), encoding="utf-8")
+    assert is_modular(str(path)) == (1, 1)
+
+
+def test_php_counts_functions_and_class(tmp_path):
+    path = tmp_path / "calc.php"
+    path.write_text(textwrap.dedent(PHP), encoding="utf-8")
+    assert is_modular(str(path)) == (1, 1)
+
+
+def test_go_counts_funcs(tmp_path):
+    path = tmp_path / "main.go"
+    path.write_text(textwrap.dedent(GO), encoding="utf-8")
+    assert is_modular(str(path)) == (1, 0)
+
+
+def test_perl_counts_subs_and_package(tmp_path):
+    path = tmp_path / "utils.pl"
+    path.write_text(textwrap.dedent(PERL), encoding="utf-8")
+    assert is_modular(str(path)) == (1, 1)
+
+
+def test_python_counts_unchanged(tmp_path):
+    path = tmp_path / "mod.py"
+    path.write_text(textwrap.dedent(PYTHON), encoding="utf-8")
+    assert is_modular(str(path)) == (1, 1)
+
+
+def test_javascript_counts_unchanged(tmp_path):
+    path = tmp_path / "mod.js"
+    path.write_text(textwrap.dedent(JAVASCRIPT), encoding="utf-8")
+    assert is_modular(str(path)) == (1, 1)


### PR DESCRIPTION
## Motivation

`is_modular` ([compass_metrics/code_readability.py:92](https://github.com/oss-compass/compass-metrics-model/blob/main/compass_metrics/code_readability.py#L92)) decides whether a line declares a function by checking the keyword a line starts with — but the keyword table is wrong for most languages:

```python
elif language in ['java', 'javascript', 'php', 'go']:
    function_syntax = 'function' if language == 'javascript' else 'def '
```

* **java, php, go** get Python's `'def '` keyword, which never appears in those languages → `function_count` is **always 0**.
* **perl** is grouped with python/ruby and also gets `'def '` — perl declares functions with `sub`.
* **java classes** are declared with access modifiers (`public class Foo {`), so `startswith('class ')` never matches either → `class_count` is also always 0 for java.

`is_modular` feeds the `code_readability` metric registered in `compass_model/base_metrics_model.py` (line 704), so java/php/go/perl repositories were silently reported with zero function/class counts.

## Change

Use each language's own declaration keyword:

```python
elif language == 'perl':
    function_syntax = 'sub '
    class_syntax = 'package '
elif language in ['javascript', 'php', 'go']:
    function_syntax = {'javascript': 'function', 'php': 'function ', 'go': 'func '}[language]
    class_syntax = 'class '
elif language in ['java', 'c', 'cpp']:
    function_syntax = re.compile(r'\w+\s+\w+\s*\([^)]*\)\s*{')
    class_syntax = 'class '
```

Java is routed through the same signature regex already used for c/cpp — a java method declaration `void main(String[] args) {` matches it — and java's modifier-prefixed `public class Foo {` is found by the substring class check that c/cpp already use. Control statements (`if (x) {`, `while (x) {`) do not match the regex because it requires two identifiers before the parameter list.

Shell and R have no fixed function-declaration keyword and remain uncounted, exactly as before.

## Verification

Added `tests/test_is_modular.py` (writes sample files to pytest `tmp_path`; no repo checkout or network needed). Fail-before / pass-after:

```
$ python -m pytest tests/test_is_modular.py -q
# before fix
FAILED test_java_counts_methods_and_class      # assert (0, 0) == (1, 1)
FAILED test_php_counts_functions_and_class     # assert (0, 1) == (1, 1)
FAILED test_go_counts_funcs                    # assert (0, 0) == (1, 0)
FAILED test_perl_counts_subs_and_package       # assert (0, 0) == (1, 1)
2 passed                                       # python + javascript controls

# after fix
6 passed
```

The python and javascript controls confirm the already-working languages are unchanged. Full suite and flake8 (repo config `ignore = E501`) are clean.

Signed-off-by: zjncs <18910855655@163.com>