### PR TITLE
fix: README files never found because isfile() checked the CWD

### DIFF
--- a/compass_metrics/document_metric/doc_num.py
+++ b/compass_metrics/document_metric/doc_num.py
@@ -108,7 +108,7 @@ def search_readme_in_folder(path)->tuple:
     flag = False
 
     for files in os.listdir(path):
-        if not os.path.isfile(files):
+        if not os.path.isfile(os.path.join(path, files)):
             continue
         
 
@@ -127,31 +127,28 @@ def get_documentation_links_from_repo(repo_url,version,platform='github'):
         repo_url (str): The URL of the repository to clone.
         platform (str, optional): The platform where the repository is hosted. Defaults to 'github'.
     Returns:
-        dict: A dictionary containing the total number of documents, details of documents found in the folder, 
+        dict: A dictionary containing the total number of documents, details of documents found in the folder,
               and details of links found in the README file.
     Raises:
-        ValueError: If the repository clone fails or if the README file is not found in the folder.
+        ValueError: If the repository clone fails. A repository without a
+            README is not an error; its documents are still counted and no
+            README links are reported.
     """
 
 
 
     repo_name = os.path.basename(repo_url)+"-"+version
-    
+
     if repo_name not in os.listdir(TMP_PATH):
         flag,readme_path = clone_repo(repo_url,version)
         if not flag:
-            ValueError("Repository clone failed.")
+            raise ValueError("Repository clone failed.")
         else:
             print(f"Repository cloned to {readme_path}")
 
-    
+
     readme_path = os.path.join(TMP_PATH, repo_name)
-    if readme_path:
-        # print(f"Repository has already cloned to {readme_path}")
-        flag,readme = search_readme_in_folder(readme_path)
-    else:
-        ValueError("README file not found in folder.")
-    
+    flag,readme = search_readme_in_folder(readme_path)
 
     document_count, document_details = count_documents_from_folder(readme_path)
     link_count, links = count_documents_from_Readme(readme)

--- a/tests/test_doc_num_readme.py
+++ b/tests/test_doc_num_readme.py
@@ -1,0 +1,75 @@
+"""Regression tests for README detection in the doc_number metric.
+
+search_readme_in_folder checked os.path.isfile() against the process
+working directory instead of the target folder, so a README inside the
+cloned repository was never detected and its document links were never
+counted by get_documentation_links_from_repo. Additionally, the
+documented ValueError for a failed clone was constructed but never
+raised, letting the function continue with a missing repository path
+and crash later with FileNotFoundError.
+
+These tests run on temporary directories; no clone or network access is
+required.
+"""
+import pytest
+
+import compass_metrics.document_metric.doc_num as doc_num
+
+
+def test_search_readme_finds_readme_in_target_folder(tmp_path, monkeypatch):
+    repo = tmp_path / "repo-1.0"
+    repo.mkdir()
+    (repo / "README.md").write_text("# Title\n\nSee https://example.com/docs\n",
+                                    encoding="utf-8")
+    # The process working directory must not contain any README file,
+    # otherwise the isfile() check against the CWD would mask the bug.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    flag, content = doc_num.search_readme_in_folder(str(repo))
+    assert flag is True
+    assert content.startswith("# Title")
+
+
+def test_search_readme_returns_false_without_readme(tmp_path, monkeypatch):
+    repo = tmp_path / "repo-1.0"
+    repo.mkdir()
+    (repo / "main.go").write_text("package main\n", encoding="utf-8")
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    flag, content = doc_num.search_readme_in_folder(str(repo))
+    assert flag is False
+    assert content == ""
+
+
+def test_get_documentation_links_counts_readme_links(tmp_path, monkeypatch):
+    repo = tmp_path / "demo-1.0.0"
+    repo.mkdir()
+    (repo / "README.md").write_text("# Demo\n\nDocs: https://example.com/docs\n",
+                                    encoding="utf-8")
+    (repo / "docs.md").write_text("docs\n", encoding="utf-8")
+    monkeypatch.setattr(doc_num, "TMP_PATH", str(tmp_path))
+    monkeypatch.setattr(doc_num, "JSON_REPOPATH", str(tmp_path))
+    # Keep the CWD free of README files so the isfile() check against the
+    # CWD cannot mask the bug.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    result = doc_num.get_documentation_links_from_repo(
+        "https://github.com/org/demo", "1.0.0")
+    # 2 folder documents (README.md, docs.md) + 1 link from the README.
+    assert result["doc_number"] == 3
+    assert result["links_document_details"][0]["path"] == "https://example.com/docs"
+
+
+def test_clone_failure_raises_value_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(doc_num, "TMP_PATH", str(tmp_path))
+    monkeypatch.setattr(doc_num, "clone_repo", lambda url, version: (False, None))
+
+    with pytest.raises(ValueError, match="Repository clone failed"):
+        doc_num.get_documentation_links_from_repo(
+            "https://github.com/org/demo", "1.0.0")


### PR DESCRIPTION
## Motivation

`search_readme_in_folder` ([compass_metrics/document_metric/doc_num.py:110](https://github.com/oss-compass/compass-metrics-model/blob/main/compass_metrics/document_metric/doc_num.py#L110)) walks `os.listdir(path)` but tests each entry with:

```python
for files in os.listdir(path):
    if not os.path.isfile(files):   # resolves against the CWD, not path
        continue
```

`os.path.isfile(files)` resolves the bare name against the **process working directory**, not the target folder. Unless a file with the same name happens to exist in the CWD, every entry is skipped and **the README is never detected** — so `get_documentation_links_from_repo` never extracts the README's document links and the `doc_number` metric (registered in `compass_model/base_metrics_model.py`, `Industry_Support` model) silently loses all README links for every repository.

Two smaller defects in `get_documentation_links_from_repo`:

* `ValueError("Repository clone failed.")` is **constructed but never raised** (line 143). After a failed clone the function continues with a nonexistent repository path and dies later with `FileNotFoundError` from `os.listdir`, instead of the documented `ValueError`.
* The `else: ValueError("README file not found in folder.")` branch is dead code: its guard `if readme_path:` is always true because `readme_path` is the result of `os.path.join`.

## Change

1. Resolve each entry against the target folder: `os.path.isfile(os.path.join(path, files))`.
2. `raise` the clone-failure `ValueError` as documented.
3. Drop the unreachable `if readme_path: / else` wrapper and call `search_readme_in_folder` directly. A repository **without** a README stays a non-error: folder documents are still counted and 0 links are reported (this also matches the actual behavior, so the docstring's "README not found" raise clause is removed).

## Verification

Added `tests/test_doc_num_readme.py` (temporary directories, cloned-repo dir prepared directly — no clone/network). The tests `chdir` to an empty directory first, because a README-named file in the CWD masks bug 1 (that is exactly why it went unnoticed):

```
$ python -m pytest tests/test_doc_num_readme.py -q
# before fix
FAILED test_search_readme_finds_readme_in_target_folder      # flag False, content ''
FAILED test_get_documentation_links_counts_readme_links      # doc_number 2 != 3 (README link lost)
FAILED test_clone_failure_raises_value_error                  # FileNotFoundError instead of ValueError
1 passed                                                       # no-README control

# after fix
4 passed
```

Control covered: a repo without a README still returns `flag=False` and counts its folder documents. Full suite and flake8 (repo config `ignore = E501`) are clean.

Signed-off-by: zjncs <18910855655@163.com>