### PR TITLE
fix: version range wraps around for the oldest release (org_contribution always 0)

### DIFF
--- a/compass_metrics/document_metric/organizational_contribution.py
+++ b/compass_metrics/document_metric/organizational_contribution.py
@@ -67,7 +67,8 @@ def get_github_versions(repo_url,version):
         for i in range(len(versions)):
             if version in versions[i][1]:
                 end_time = versions[i][0]
-                start_time = versions[i-1][0]
+                if i > 0:
+                    start_time = versions[i-1][0]
                 flag = True
                 break
        
@@ -113,7 +114,8 @@ def get_github_versions(repo_url,version):
                 for i in range(len(versions)):
                     if version in versions[i][1]:
                         end_time = versions[i][0]
-                        start_time = versions[i-1][0]
+                        if i > 0:
+                            start_time = versions[i-1][0]
                 
                 return start_time,end_time
             else:
@@ -171,7 +173,8 @@ def get_gitee_versions(repo_url,version):
         for i in range(len(versions)):
             if version in versions[i][1]:
                 end_time = versions[i][0]
-                start_time = versions[i-1][0]
+                if i > 0:
+                    start_time = versions[i-1][0]
                 flag = True
                 break
        
@@ -217,7 +220,8 @@ def get_gitee_versions(repo_url,version):
                 for i in range(len(versions)):
                     if version in versions[i][1]:
                         end_time = versions[i][0]
-                        start_time = versions[i-1][0]
+                        if i > 0:
+                            start_time = versions[i-1][0]
                 
                 return start_time,end_time
             else:

--- a/tests/test_org_contribution_version_range.py
+++ b/tests/test_org_contribution_version_range.py
@@ -1,0 +1,84 @@
+"""Regression tests for the version time range in organizational_contribution.
+
+get_github_versions/get_gitee_versions locate the requested version in the
+chronologically sorted release list and use the previous release's date as
+the range start. When the requested version is the OLDEST one (index 0),
+versions[i-1] wraps around to versions[-1], the NEWEST release, producing an
+inverted range (start > end). The downstream OpenSearch query in
+organizational_contribution then matches nothing and org_contribution is
+always 0 for the earliest release. The start time must stay at its
+2020-01-01 default when there is no earlier release.
+
+These tests patch HTTP access and the JSON cache directory, so no network
+or API token is required.
+"""
+import sys
+
+# The package __init__ rebinds the name `organizational_contribution` to the
+# function, so import the module and fetch it from sys.modules.
+import compass_metrics.document_metric.organizational_contribution  # noqa: F401
+
+oc = sys.modules["compass_metrics.document_metric.organizational_contribution"]
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else []
+        self.links = {}
+
+    def json(self):
+        return self._json
+
+
+def releases_response():
+    return FakeResponse(json_data=[
+        {"tag_name": "v1.0.0", "published_at": "2021-01-10T00:00:00Z"},
+        {"tag_name": "v2.0.0", "published_at": "2022-02-20T00:00:00Z"},
+        {"tag_name": "v3.0.0", "published_at": "2023-03-30T00:00:00Z"},
+    ])
+
+
+def test_oldest_release_range_keeps_default_start(tmp_path, monkeypatch):
+    monkeypatch.setattr(oc, "JSON_REPOPATH", str(tmp_path))
+    monkeypatch.setattr(oc.requests, "get", lambda url, headers=None: releases_response())
+    start, end = oc.get_github_versions("https://github.com/org/demo", "v1.0.0")
+    assert end == "2021-01-10T00:00:00Z"
+    assert start == "2020-01-01T00:00:00Z"
+
+
+def test_middle_release_range_spans_previous_release(tmp_path, monkeypatch):
+    monkeypatch.setattr(oc, "JSON_REPOPATH", str(tmp_path))
+    monkeypatch.setattr(oc.requests, "get", lambda url, headers=None: releases_response())
+    start, end = oc.get_github_versions("https://github.com/org/demo", "v2.0.0")
+    assert (start, end) == ("2021-01-10T00:00:00Z", "2022-02-20T00:00:00Z")
+
+
+def test_gitee_oldest_release_range_keeps_default_start(tmp_path, monkeypatch):
+    monkeypatch.setattr(oc, "JSON_REPOPATH", str(tmp_path))
+    monkeypatch.setattr(oc.requests, "get", lambda url, headers=None: releases_response())
+    start, end = oc.get_gitee_versions("https://gitee.com/org/demo", "v1.0.0")
+    assert end == "2021-01-10T00:00:00Z"
+    assert start == "2020-01-01T00:00:00Z"
+
+
+def test_oldest_tag_range_keeps_default_start(tmp_path, monkeypatch):
+    # Empty /releases response forces the /tags fallback path.
+    def fake_get(url, headers=None):
+        if url.endswith("/tags"):
+            return FakeResponse(json_data=[
+                {"name": "v1.0.0",
+                 "commit": {"url": "https://api.github.com/repos/org/demo/commits/aaa"}},
+                {"name": "v2.0.0",
+                 "commit": {"url": "https://api.github.com/repos/org/demo/commits/bbb"}},
+            ])
+        if "/commits/" in url:
+            date = "2021-01-10T00:00:00Z" if url.endswith("aaa") else "2022-02-20T00:00:00Z"
+            return FakeResponse(json_data={"commit": {"committer": {"date": date}}})
+        return FakeResponse(json_data=[])
+
+    monkeypatch.setattr(oc, "JSON_REPOPATH", str(tmp_path))
+    monkeypatch.setattr(oc.requests, "get", fake_get)
+    start, end = oc.get_github_versions("https://github.com/org/demo", "v1.0.0")
+    assert end == "2021-01-10T00:00:00Z"
+    assert start == "2020-01-01T00:00:00Z"


### PR DESCRIPTION
## Motivation

`get_github_versions`/`get_gitee_versions` ([compass_metrics/document_metric/organizational_contribution.py](https://github.com/oss-compass/compass-metrics-model/blob/main/compass_metrics/document_metric/organizational_contribution.py)) locate the requested version in the chronologically sorted release list and use the previous release's date as the range start:

```python
for i in range(len(versions)):
    if version in versions[i][1]:
        end_time = versions[i][0]
        start_time = versions[i-1][0]   # i == 0 -> versions[-1] == NEWEST release
        flag = True
        break
```

When the requested version is the **oldest** one (`i == 0`), `versions[i-1]` wraps around to `versions[-1]` — the **newest** release — so `start_time > end_time`. The downstream OpenSearch query in `organizational_contribution` then filters on that inverted range:

```python
"range": {"grimoire_creation_date": {"gte": start_time, "lte": end_time}}
```

matches **nothing**, and `org_contribution`/`personal` are always **0** for the earliest release of a repository. The metric is registered in `compass_model/base_metrics_model.py` (`Industry_Support` model).

The same `versions[i-1]` pattern exists in **4 places**: the github releases loop, the github `/tags` fallback loop, and both loops of the gitee twin `get_gitee_versions`.

## Change

Keep the documented 2020-01-01 default start time when there is no earlier release:

```diff
             end_time = versions[i][0]
-            start_time = versions[i-1][0]
+            if i > 0:
+                start_time = versions[i-1][0]
```

applied to all 4 loops.

## Verification

Added `tests/test_org_contribution_version_range.py` — HTTP access (`requests.get`) and the JSON cache directory are patched, so no network or API token is needed:

| case | before | after |
|---|---|---|
| oldest release, github releases path | start = newest release date (2023-03-30) | start = 2020-01-01 default |
| oldest release, gitee releases path | same wraparound | 2020-01-01 default |
| oldest tag, github `/tags` fallback | same wraparound | 2020-01-01 default |
| middle release (control) | spans previous release | unchanged |

```
$ python -m pytest tests/test_org_contribution_version_range.py -q
# before fix
FAILED test_oldest_release_range_keeps_default_start
FAILED test_gitee_oldest_release_range_keeps_default_start
FAILED test_oldest_tag_range_keeps_default_start
1 passed   # middle-release control

# after fix
4 passed
```

Full suite and flake8 (repo config `ignore = E501`) are clean.

Signed-off-by: zjncs <18910855655@163.com>