### PR TITLE
fix: signed_releases never matches .asc and .sig signature files

### DIFF
--- a/compass_metrics/opencheck_metrics.py
+++ b/compass_metrics/opencheck_metrics.py
@@ -110,20 +110,22 @@ def license(client, openchecker_index, repo_list):
 
 def signed_releases(client, openchecker_index, repo_list):
     """ Does the project cryptographically sign releases? """
-    file_suffix = [".minisig", ".asc (pgp)", "*.sig", ".sign", ".sigstore", ".intoto.jsonl"]
-    
+    # The release-checker collects signature files as plain asset filenames
+    # whose lowercase name ends with one of these extensions.
+    file_suffix = [".minisig", ".asc", ".sig", ".sign", ".sigstore", ".intoto.jsonl"]
+
     release_list = []
     signed_release_list = []
-    
+
     openchecker_data = get_openchecker_data(client, openchecker_index, repo_list[0], "release-checker")
     if openchecker_data is not None:
         command_result_list = deep_get(openchecker_data, ["_source", "command_result", "signed-release-checker", "signed_files"], [])
         for item in command_result_list[:5]:
-            release_list.append(item["release_name"]) 
+            release_list.append(item["release_name"])
             matched_files = [
                 sig_file
                 for sig_file in item["signature_files"]
-                if any(suffix in sig_file for suffix in file_suffix)
+                if any(sig_file.lower().endswith(suffix) for suffix in file_suffix)
             ]
             if len(matched_files) > 0:
                 signed_release_list.append(item["release_name"])

--- a/tests/test_signed_releases_suffix.py
+++ b/tests/test_signed_releases_suffix.py
@@ -1,0 +1,88 @@
+"""Regression tests for signature file matching in signed_releases.
+
+The release-checker producer (openchecker) collects signature files as
+plain asset filenames whose lowercase name ends with one of
+".minisig", ".asc", ".sig", ".sign", ".sigstore", ".intoto.jsonl".
+The signed_releases consumer however matched the suffixes
+".asc (pgp)" and "*.sig" as substrings - neither can ever occur in a
+filename - so PGP .asc signatures and plain .sig signatures were never
+counted as signed, while substring matching also let non-signature
+files containing ".sign" (e.g. "banner.signoff.png") pass as signatures.
+
+These tests patch the OpenSearch access, so no instance or network
+access is required.
+"""
+from compass_metrics.opencheck_metrics import signed_releases
+
+
+def openchecker_doc(releases):
+    return {
+        "_source": {
+            "command_result": {
+                "signed-release-checker": {
+                    "signed_files": releases
+                }
+            }
+        }
+    }
+
+
+def run_signed_releases(monkeypatch, releases):
+    doc = openchecker_doc(releases)
+    monkeypatch.setattr("compass_metrics.opencheck_metrics.get_openchecker_data",
+                        lambda client, index, repo, command: doc)
+    return signed_releases(None, "openchecker", ["https://github.com/org/repo"])
+
+
+def test_asc_pgp_signature_is_counted(monkeypatch):
+    result = run_signed_releases(monkeypatch, [
+        {"release_name": "v1.0.0", "signature_files": ["release.tar.gz.asc"]},
+    ])
+    assert result["signed_releases"] == 10
+    assert result["signed_releases_detail"]["signed_release_list"] == ["v1.0.0"]
+
+
+def test_plain_sig_signature_is_counted(monkeypatch):
+    result = run_signed_releases(monkeypatch, [
+        {"release_name": "v1.0.0", "signature_files": ["checksums.sig"]},
+    ])
+    assert result["signed_releases"] == 10
+
+
+def test_mixed_case_signature_is_counted(monkeypatch):
+    result = run_signed_releases(monkeypatch, [
+        {"release_name": "v1.0.0", "signature_files": ["ARTIFACT.TAR.GZ.ASC"]},
+    ])
+    assert result["signed_releases"] == 10
+
+
+def test_minisig_signature_still_counted(monkeypatch):
+    result = run_signed_releases(monkeypatch, [
+        {"release_name": "v1.0.0", "signature_files": ["release.tar.xz.minisig"]},
+    ])
+    assert result["signed_releases"] == 10
+
+
+def test_file_containing_sign_text_is_not_a_signature(monkeypatch):
+    # "banner.signoff.png" merely contains the substring ".sign"; it must
+    # not be treated as a signature file.
+    result = run_signed_releases(monkeypatch, [
+        {"release_name": "v1.0.0", "signature_files": ["banner.signoff.png"]},
+    ])
+    assert result["signed_releases"] == 0
+    assert result["signed_releases_detail"]["signed_release_list"] == []
+
+
+def test_half_signed_releases_score(monkeypatch):
+    result = run_signed_releases(monkeypatch, [
+        {"release_name": "v1.0.0", "signature_files": ["release.tar.gz.asc"]},
+        {"release_name": "v2.0.0", "signature_files": []},
+    ])
+    assert result["signed_releases"] == 5
+
+
+def test_no_release_data_returns_none(monkeypatch):
+    monkeypatch.setattr("compass_metrics.opencheck_metrics.get_openchecker_data",
+                        lambda client, index, repo, command: None)
+    result = signed_releases(None, "openchecker", ["https://github.com/org/repo"])
+    assert result["signed_releases"] is None


### PR DESCRIPTION
## Motivation

`signed_releases` ([compass_metrics/opencheck_metrics.py:111](https://github.com/oss-compass/compass-metrics-model/blob/main/compass_metrics/opencheck_metrics.py#L111)) decides whether a release is signed by matching the asset filenames produced by the release-checker against a suffix list:

```python
file_suffix = [".minisig", ".asc (pgp)", "*.sig", ".sign", ".sigstore", ".intoto.jsonl"]
...
if any(suffix in sig_file for suffix in file_suffix)
```

But the producer — openchecker's `release_checker.py` (`check_signed_release`) — collects signature files as **plain asset filenames** whose lowercase name **ends with** one of:

```python
signature_exts = [".minisig", ".asc", ".sig", ".sign", ".sigstore", ".intoto.jsonl"]
found_files = [a['name'] for a in assets if any(a['name'].lower().endswith(ext) for ext in signature_exts)]
```

Two entries of the consumer list can **never** occur in a filename:

* ``.asc (pgp)`` — the `" (pgp)"` annotation is not part of any filename → **PGP `.asc` signatures are never counted** (`.asc` is the most common detached-signature extension).
* ``*.sig`` — a filename never contains a literal `*` → **plain `.sig` signatures are never counted**.

So projects signing releases with PGP `.asc` or `.sig` files get an understated `signed_releases` score (registered in `compass_model/base_metrics_model.py` line 733). Conversely, substring matching lets a non-signature asset that merely *contains* ``.sign`` — e.g. `banner.signoff.png` — pass as a signature.

## Change

Match exactly like the producer: the real extension list, a lowercased filename, and a suffix comparison:

```diff
-file_suffix = [".minisig", ".asc (pgp)", "*.sig", ".sign", ".sigstore", ".intoto.jsonl"]
+file_suffix = [".minisig", ".asc", ".sig", ".sign", ".sigstore", ".intoto.jsonl"]
...
-                if any(suffix in sig_file for suffix in file_suffix)
+                if any(sig_file.lower().endswith(suffix) for suffix in file_suffix)
```

## Verification

Added `tests/test_signed_releases_suffix.py` (`get_openchecker_data` patched; no OpenSearch instance or network needed). Fail-before / pass-after:

```
$ python -m pytest tests/test_signed_releases_suffix.py -q
# before fix
FAILED test_asc_pgp_signature_is_counted          # score 0, expected 10
FAILED test_plain_sig_signature_is_counted        # score 0, expected 10
FAILED test_mixed_case_signature_is_counted       # score 0, expected 10
FAILED test_file_containing_sign_text_is_not_a_signature  # banner.signoff.png counted
FAILED test_half_signed_releases_score            # 0, expected 5
2 passed                                          # .minisig + no-data controls

# after fix
7 passed
```

Full suite and flake8 (repo config `ignore = E501`) are clean.

Signed-off-by: zjncs <18910855655@163.com>