### PR TITLE
fix: issue ratios return None instead of 0.0 when the numerator is zero

### DIFF
--- a/compass_metrics/issue_metrics.py
+++ b/compass_metrics/issue_metrics.py
@@ -172,7 +172,7 @@ def issue_unresponsive_ratio(client, issue_index, date, repo_list, from_date=Non
     total_count = issue_count(client, issue_index, date, repo_list, from_date)["issue_count"]
 
     result = {
-        "issue_unresponsive_ratio": count/total_count if count > 0 else None
+        "issue_unresponsive_ratio": count/total_count if total_count > 0 else None
     }
     return result
 
@@ -186,7 +186,7 @@ def issue_completion_ratio(client, issue_index, date, repo_list, from_date=None)
     total_count = issue_count(client, issue_index, date, repo_list, from_date)["issue_count"]
 
     result = {
-        "issue_completion_ratio": count/total_count if count > 0 else None
+        "issue_completion_ratio": count/total_count if total_count > 0 else None
     }
     return result
 
@@ -314,7 +314,7 @@ def issue_completion_ratio_year(client, issue_index, date, repo_list, from_date=
     total_count = issue_count(client, issue_index, date, repo_list, from_date)["issue_count"]
 
     result = {
-        "issue_completion_ratio_year": count/total_count if count > 0 else None
+        "issue_completion_ratio_year": count/total_count if total_count > 0 else None
     }
     return result
 

--- a/tests/test_issue_completion_ratio_guard.py
+++ b/tests/test_issue_completion_ratio_guard.py
@@ -1,0 +1,67 @@
+"""Regression tests for the no-data guard of the issue ratio metrics.
+
+issue_unresponsive_ratio, issue_completion_ratio and
+issue_completion_ratio_year guarded the NUMERATOR ('count > 0'), so a
+window with issues but zero closed/unresponsive issues returned None
+("no data") instead of the meaningful ratio 0.0. The codebase idiom
+guards the DENOMINATOR (see pr_issue_linked_ratio in pr_metrics.py and
+commit_pr_linked_ratio in git_metrics.py): a ratio is undefined only
+when the total is zero, and zero-over-N is a valid 0.0.
+
+These tests patch the count helpers, so no OpenSearch instance or
+network access is required.
+"""
+import datetime
+
+import compass_metrics.issue_metrics as im
+
+DATE = datetime.date(2026, 9, 6)
+REPOS = ["https://github.com/oss-compass/compass-metrics-model"]
+
+
+def patch_close_counts(monkeypatch, closed, total):
+    monkeypatch.setattr(
+        im, "create_close_issue_count",
+        lambda client, index, date, repos, from_date=None: {"create_close_issue_count": closed})
+    monkeypatch.setattr(
+        im, "issue_count",
+        lambda client, index, date, repos, from_date=None: {"issue_count": total})
+
+
+def test_completion_ratio_zero_when_issues_exist_but_none_closed(monkeypatch):
+    patch_close_counts(monkeypatch, 0, 10)
+    assert im.issue_completion_ratio(
+        None, "issue", DATE, REPOS)["issue_completion_ratio"] == 0.0
+
+
+def test_completion_ratio_year_zero_when_issues_exist_but_none_closed(monkeypatch):
+    patch_close_counts(monkeypatch, 0, 10)
+    assert im.issue_completion_ratio_year(
+        None, "issue", DATE, REPOS)["issue_completion_ratio_year"] == 0.0
+
+
+def test_unresponsive_ratio_zero_when_all_issues_answered(monkeypatch):
+    monkeypatch.setattr(
+        im, "issue_unresponsive_count",
+        lambda client, index, date, repos, from_date=None: {"issue_unresponsive_count": 0})
+    monkeypatch.setattr(
+        im, "issue_count",
+        lambda client, index, date, repos, from_date=None: {"issue_count": 10})
+    assert im.issue_unresponsive_ratio(
+        None, "issue", DATE, REPOS)["issue_unresponsive_ratio"] == 0.0
+
+
+def test_completion_ratios_value_unchanged(monkeypatch):
+    patch_close_counts(monkeypatch, 4, 10)
+    assert im.issue_completion_ratio(
+        None, "issue", DATE, REPOS)["issue_completion_ratio"] == 0.4
+    assert im.issue_completion_ratio_year(
+        None, "issue", DATE, REPOS)["issue_completion_ratio_year"] == 0.4
+
+
+def test_completion_ratio_none_without_issues(monkeypatch):
+    patch_close_counts(monkeypatch, 0, 0)
+    assert im.issue_completion_ratio(
+        None, "issue", DATE, REPOS)["issue_completion_ratio"] is None
+    assert im.issue_completion_ratio_year(
+        None, "issue", DATE, REPOS)["issue_completion_ratio_year"] is None


### PR DESCRIPTION
## Motivation

Three issue ratio metrics in `compass_metrics/issue_metrics.py` guard the **numerator** instead of the **denominator**:

```python
"issue_unresponsive_ratio":    count/total_count if count > 0 else None   # line 175
"issue_completion_ratio":      count/total_count if count > 0 else None   # line 190
"issue_completion_ratio_year": count/total_count if count > 0 else None   # line 319
```

A window with 10 created issues and **0 closed** issues is not missing data — the completion ratio is a perfectly meaningful **0.0** — yet these metrics return `None`, which downstream scoring treats as *unknown* (skip/decay) rather than a measured zero. `None` is only correct when the total is zero (no issues at all).

The codebase idiom guards the **denominator**; e.g. `pr_issue_linked_ratio` (`pr_metrics.py:246`) and `commit_pr_linked_ratio` (`git_metrics.py:289`):

```python
"pr_issue_linked_ratio": code_pr_issue_linked_count/code_pr_count if code_pr_count > 0 else None
```

The numerator can never exceed `total_count`: `issue_unresponsive_count` and `create_close_issue_count` add filters (`num_of_comments_without_bot`/`state`, closed-in-window) **on top of** `issue_count`'s base query over the same window, so `count <= total_count` always holds and guarding `total_count` is also what keeps the division safe.

`issue_completion_ratio_year` is registered in `compass_model/base_metrics_model.py` (line 641), so the 0.0-vs-None distinction affects production scoring.

## Change

```diff
-"issue_completion_ratio": count/total_count if count > 0 else None
+"issue_completion_ratio": count/total_count if total_count > 0 else None
```

for all three ratios.

## Verification

Added `tests/test_issue_completion_ratio_guard.py` (count helpers patched; no OpenSearch instance needed). Fail-before / pass-after:

```
$ python -m pytest tests/test_issue_completion_ratio_guard.py -q
# before fix
FAILED test_completion_ratio_zero_when_issues_exist_but_none_closed       # None != 0.0
FAILED test_completion_ratio_year_zero_when_issues_exist_but_none_closed # None != 0.0
FAILED test_unresponsive_ratio_zero_when_all_issues_answered             # None != 0.0
2 passed   # 4/10 value case + no-issues None case (controls)

# after fix
5 passed
```

Full suite and flake8 (repo config `ignore = E501`) are clean.

Signed-off-by: zjncs <18910855655@163.com>